### PR TITLE
Revert search bar width override

### DIFF
--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -7,9 +7,3 @@
     --vp-sidebar-width: 360px;
   }
 }
-
-@media (min-width: 768px) {
-  .VPNavBarSearch .DocSearch-Button {
-    width: 240px;
-  }
-}


### PR DESCRIPTION
## Summary
- Remove the `.VPNavBarSearch .DocSearch-Button { width: 240px; }` block. Default VitePress sizing is fine; the override was unnecessary.

## Test plan
- [ ] `npm run dev` and confirm the navbar search button renders at its default width.
- [ ] Confirm the search modal still opens via Ctrl+K and search returns results.