### PR TITLE
Document the autoresponder

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -111,6 +111,10 @@ export default {
             link: "/dashboard/email-notification-settings",
           },
           {
+            text: "Autoresponder",
+            link: "/dashboard/autoresponder",
+          },
+          {
             text: "Exporting submissions",
             link: "/dashboard/exporting-submissions",
           },

--- a/docs/customization/notification-email.md
+++ b/docs/customization/notification-email.md
@@ -57,6 +57,8 @@ Create a hidden input with the name `_email.template.footer` and the value `fals
 
 ## Custom templates
 
+You can go beyond these options and design the notification email in a visual template editor, built in partnership with [Postcraft](https://postcraft.io/).
+
 [Check this page](/dashboard/email-notification-settings.html#custom-templates) to learn more about custom email
 templates.
 

--- a/docs/customization/notification-email.md
+++ b/docs/customization/notification-email.md
@@ -59,3 +59,7 @@ Create a hidden input with the name `_email.template.footer` and the value `fals
 
 [Check this page](/dashboard/email-notification-settings.html#custom-templates) to learn more about custom email
 templates.
+
+## Autoresponder
+
+Notification emails go to you; the [autoresponder](/dashboard/autoresponder.html) sends a confirmation email to the person who submitted your form.

--- a/docs/dashboard/autoresponder.md
+++ b/docs/dashboard/autoresponder.md
@@ -41,15 +41,6 @@ Replies to an autoresponse go to your form's first notification recipient, so a 
 
 Every autoresponse includes a footer identifying the form it was sent on behalf of, along with an unsubscribe link. Recipients who unsubscribe stop receiving autoresponses; the footer cannot be removed.
 
-## Sending limits
-
-To protect recipients and email deliverability, autoresponses are subject to daily limits:
-
-- at most 200 autoresponses per form per day,
-- at most 1,000 autoresponses per workspace per day.
-
-Submissions beyond these limits are stored and delivered to you as usual; only the autoresponse is skipped.
-
 ## Content policy
 
 The rendered autoresponse is automatically checked before every send. Autoresponses that classify as spam are not sent, and repeated detections disable the autoresponder for the workspace. Use the autoresponder for transactional confirmations, not for marketing or bulk email.

--- a/docs/dashboard/autoresponder.md
+++ b/docs/dashboard/autoresponder.md
@@ -1,0 +1,59 @@
+---
+title: Autoresponder
+lang: en-US
+---
+
+# Autoresponder
+
+The autoresponder automatically sends a confirmation email to the person who submitted your form.
+
+The autoresponder is available on all paid workspaces.
+
+## Enabling the autoresponder
+
+To enable the autoresponder for a form, navigate to its `Settings` section and create an autoresponder template.
+
+The template is designed in a visual editor, built in partnership with [Postcraft](https://postcraft.io/). Add your own copy and imagery, and include a recap of the submitted data.
+
+## Who receives the autoresponse
+
+Formspark determines the recipient from your form's submission data. The first of the following fields that contains a valid email address is used:
+
+1. `_replyto`
+2. `mail`
+3. `email`
+
+```html
+<input type="email" name="email" />
+```
+
+If the submission contains no valid email address in these fields, no autoresponse is sent.
+
+::: tip
+The same fields also set the reply-to address of your own notification emails, so a form that supports direct replies already works with the autoresponder.
+:::
+
+## Replies
+
+Replies to an autoresponse go to your form's first notification recipient, so a submitter who answers the confirmation email reaches you, not Formspark.
+
+## Footer and unsubscribe
+
+Every autoresponse includes a footer identifying the form it was sent on behalf of, along with an unsubscribe link. Recipients who unsubscribe stop receiving autoresponses; the footer cannot be removed.
+
+## Sending limits
+
+To protect recipients and email deliverability, autoresponses are subject to daily limits:
+
+- at most 200 autoresponses per form per day,
+- at most 1,000 autoresponses per workspace per day.
+
+Submissions beyond these limits are stored and delivered to you as usual; only the autoresponse is skipped.
+
+## Content policy
+
+The rendered autoresponse is automatically checked before every send. Autoresponses that classify as spam are not sent, and repeated detections disable the autoresponder for the workspace. Use the autoresponder for transactional confirmations, not for marketing or bulk email.
+
+::: warning
+Spam-flagged submissions never trigger an autoresponse, and neither do submissions blocked by your form's spam protection.
+:::

--- a/docs/dashboard/autoresponder.md
+++ b/docs/dashboard/autoresponder.md
@@ -43,8 +43,8 @@ Every autoresponse includes a footer identifying the form it was sent on behalf 
 
 ## Content policy
 
-The rendered autoresponse is automatically checked before every send. Autoresponses that classify as spam are not sent, and repeated detections disable the autoresponder for the workspace. Use the autoresponder for transactional confirmations, not for marketing or bulk email.
+Use the autoresponder for transactional confirmations, not for marketing or bulk email.
 
 ::: warning
-Spam-flagged submissions never trigger an autoresponse, and neither do submissions blocked by your form's spam protection.
+Spam-flagged submissions never trigger an autoresponse.
 :::

--- a/docs/dashboard/email-notification-settings.md
+++ b/docs/dashboard/email-notification-settings.md
@@ -18,7 +18,9 @@ To manage your form's email notification settings, navigate to its `Settings` se
 
 You can customize the notification email template of a form.
 
-Formspark custom email templates use the [Handlebars](https://handlebarsjs.com/) templating language.
+Templates are designed in a visual editor, built in partnership with [Postcraft](https://postcraft.io/).
+
+Dynamic values in a template use the [Handlebars](https://handlebarsjs.com/) templating language.
 
 ```handlebars
 <div style="text-align: left;">


### PR DESCRIPTION
Adds `/dashboard/autoresponder`: how the recipient is resolved (`_replyto`, `mail`, `email`), where replies go, the mandatory footer and unsubscribe link, and the content policy. Registered in the Dashboard sidebar group and cross-linked from the notification email page.

Companion to formspark/monorepo#42; merge after the feature deploys. A dashboard screenshot (`docs/public/autoresponder.png`) can be added as a follow-up; the page ships without an image for now.