### PR TITLE
Replace the retired Akismet section with automatic OOPSpam filtering

### DIFF
--- a/docs/setup/spam-protection.md
+++ b/docs/setup/spam-protection.md
@@ -13,9 +13,10 @@ Formspark offers the following solutions to prevent spam:
 - [reCAPTCHA](https://www.google.com/recaptcha/about/) integration
 - [hCaptcha](https://www.hcaptcha.com/) integration
 - [Turnstile](https://www.cloudflare.com/products/turnstile/) integration
-- [Akismet](https://akismet.com/) integration
 - Custom spam words
 - Honeypot technique
+
+On top of whichever of these you enable, every submission is also screened by our [automatic spam filtering](#automatic-spam-filtering).
 
 ![Spam protection](/spam-protection.png)
 
@@ -33,7 +34,6 @@ Formspark will not save submissions, send notifications or decrement your submis
 | [Turnstile](https://www.cloudflare.com/products/turnstile/) | Invisible          | Free        | Strong   |
 | [hCaptcha](https://www.hcaptcha.com/)                       | Checkbox           | Free        | Strong   |
 | [reCAPTCHA](https://www.google.com/recaptcha/about/)        | Checkbox           | Free        | Strong   |
-| [Akismet](https://akismet.com/)                             | Invisible          | Included    | Medium   |
 | Custom spam words                                           | Invisible          | Included    | Low      |
 | Honeypot                                                    | Invisible          | Included    | Low      |
 
@@ -219,11 +219,11 @@ const body = {
 
 - React: [react-turnstile](https://github.com/Le0Developer/react-turnstile)
 
-## Akismet
+## Automatic spam filtering
 
-Formspark integrates with Akismet, a spam filtering service.
+On top of any provider you choose, Formspark automatically screens every submission for spam. This runs on all forms, requires no setup, and is invisible to your visitors.
 
-This integration requires no additional setup, it is pre-activated for all accounts.
+The filtering is powered by [OOPSpam](https://www.oopspam.com/). Because it runs automatically, there is nothing to configure, and it complements the provider you select above rather than replacing it.
 
 ## Custom spam words
 


### PR DESCRIPTION
## What

Corrects `setup/spam-protection.md`, which presented **Akismet** as a selectable spam provider and as an always-on filter "pre-activated for all accounts." Neither is true anymore.

- The dashboard's Spam Protection dropdown offers only Botpoison, Google reCAPTCHA v2, hCaptcha and Turnstile. Akismet is not an option.
- The backend only handles those four providers and rejects anything else; `AKISMET` survives in the enum for back-compat only.
- The real always-on filter is now **OOPSpam**, which was undocumented. It runs automatically on every form (after the form's own checks pass), requires no setup, and is invisible to visitors.

## Changes

- Remove Akismet from the intro solutions list and add a pointer to the automatic filtering.
- Remove the Akismet row from the "Which should I pick?" comparison table (OOPSpam is not user-selectable, so it is intentionally not a table row).
- Replace the `## Akismet` section with `## Automatic spam filtering`, describing the always-on OOPSpam screening that runs on top of any provider you choose.

## Notes

- Every Akismet reference across the whole docs site was in this one file; none remain.
- The `spam-protection.png` screenshot is mildly stale in a separate way (missing Turnstile), worth a re-capture but out of scope here.