### PR TITLE
Document the API

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -121,6 +121,16 @@ export default {
         ],
       },
       {
+        text: "API",
+        items: [
+          { text: "Overview", link: "/api/" },
+          { text: "API tokens", link: "/api/api-tokens" },
+          { text: "Reference", link: "/api/reference" },
+          { text: "Pagination", link: "/api/pagination" },
+          { text: "Errors", link: "/api/errors" },
+        ],
+      },
+      {
         text: "HTML form",
         items: [
           { text: "Form validation", link: "/html-form/form-validation" },

--- a/docs/api/api-tokens.md
+++ b/docs/api/api-tokens.md
@@ -1,0 +1,68 @@
+---
+title: API tokens
+lang: en-US
+---
+
+# API tokens
+
+Create one in the dashboard under
+[API tokens](https://dashboard.formspark.io/account/api-tokens).
+
+**The token is shown once, when you create it.** Nothing stores the secret, so
+it cannot be shown again. If you lose it, revoke it and create another.
+
+## What a token can reach
+
+A token belongs to you, not to a workspace, and reaches every workspace you are
+a member of. Losing membership of a workspace takes the token's access to it
+away too.
+
+Within that, the scopes you pick decide what it may do. Give a token the least
+it needs: a script that reads submissions has no reason to hold
+`submissions:write`.
+
+| Scope               | Allows                                 |
+| ------------------- | -------------------------------------- |
+| `workspaces:read`   | List workspaces and read their details |
+| `workspaces:write`  | Create and rename workspaces           |
+| `forms:read`        | List forms and read their settings     |
+| `forms:write`       | Create, update and delete forms        |
+| `submissions:read`  | Read submissions                       |
+| `submissions:write` | Delete submissions                     |
+
+`GET /me` needs no scope at all, so a token can always describe itself.
+
+## What a token cannot do
+
+Some things are deliberately absent from the API rather than merely unscoped, so
+no token can reach them however it was created:
+
+- Deleting a workspace
+- Inviting, promoting or removing team members
+- Anything to do with billing
+- Creating or revoking API tokens
+
+Token management stays in the dashboard on purpose. A token that could mint
+tokens would turn a single leak into access that renews itself.
+
+## Expiry and revocation
+
+Tokens default to 90 days. Pick `Never` if something unattended depends on it,
+and accept that you then own rotating it.
+
+Revoking takes effect immediately. A revoked token, an expired token and one
+that never existed all fail identically, so nobody can use the API to work out
+which secrets were once real.
+
+## Keeping the secret safe
+
+Read it from the environment:
+
+```sh
+export FORMSPARK_TOKEN="fsk_live_..."
+curl https://api.formspark.io/public/v1/me \
+  -H "Authorization: Bearer $FORMSPARK_TOKEN"
+```
+
+Avoid putting it directly on a command line. Arguments are visible to other
+processes on the machine and land in your shell history.

--- a/docs/api/api-tokens.md
+++ b/docs/api/api-tokens.md
@@ -5,21 +5,13 @@ lang: en-US
 
 # API tokens
 
-Create one in the dashboard under
-[API tokens](https://dashboard.formspark.io/account/api-tokens).
+Create a token in the dashboard under [API tokens](https://dashboard.formspark.io/account/api-tokens).
 
-**The token is shown once, when you create it.** Nothing stores the secret, so
-it cannot be shown again. If you lose it, revoke it and create another.
+The token is shown once, when you create it. Store it somewhere safe. If you lose it, revoke it and create another.
 
-## What a token can reach
+## Scopes
 
-A token belongs to you, not to a workspace, and reaches every workspace you are
-a member of. Losing membership of a workspace takes the token's access to it
-away too.
-
-Within that, the scopes you pick decide what it may do. Give a token the least
-it needs: a script that reads submissions has no reason to hold
-`submissions:write`.
+A token belongs to you and reaches every workspace you are a member of. Its scopes decide what it may do there. Give a token the least it needs.
 
 | Scope               | Allows                                 |
 | ------------------- | -------------------------------------- |
@@ -30,31 +22,19 @@ it needs: a script that reads submissions has no reason to hold
 | `submissions:read`  | Read submissions                       |
 | `submissions:write` | Delete submissions                     |
 
-`GET /me` needs no scope at all, so a token can always describe itself.
+`GET /me` works with any token, so a token can always describe itself.
 
-## What a token cannot do
+Billing, team management, workspace deletion and token management stay in the dashboard.
 
-Some things are deliberately absent from the API rather than merely unscoped, so
-no token can reach them however it was created:
+## Expiry
 
-- Deleting a workspace
-- Inviting, promoting or removing team members
-- Anything to do with billing
-- Creating or revoking API tokens
+Tokens expire after 90 days by default. Choose `Never` for something unattended, and rotate it yourself.
 
-Token management stays in the dashboard on purpose. A token that could mint
-tokens would turn a single leak into access that renews itself.
+## Revocation
 
-## Expiry and revocation
+Revoking takes effect immediately.
 
-Tokens default to 90 days. Pick `Never` if something unattended depends on it,
-and accept that you then own rotating it.
-
-Revoking takes effect immediately. A revoked token, an expired token and one
-that never existed all fail identically, so nobody can use the API to work out
-which secrets were once real.
-
-## Keeping the secret safe
+## Using a token
 
 Read it from the environment:
 
@@ -64,5 +44,4 @@ curl https://api.formspark.io/public/v1/me \
   -H "Authorization: Bearer $FORMSPARK_TOKEN"
 ```
 
-Avoid putting it directly on a command line. Arguments are visible to other
-processes on the machine and land in your shell history.
+Keep it out of command-line arguments, which are visible to other processes and stored in your shell history.

--- a/docs/api/errors.md
+++ b/docs/api/errors.md
@@ -1,0 +1,96 @@
+---
+title: API errors
+lang: en-US
+---
+
+# Errors
+
+Failures are returned as [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457)
+problem details, with the content type `application/problem+json`:
+
+```json
+{
+  "type": "https://documentation.formspark.io/api/errors#insufficient-scope",
+  "title": "Insufficient scope",
+  "status": 403,
+  "detail": "This token has forms:read; forms:write is required.",
+  "code": "insufficient_scope",
+  "requiredScope": "forms:write"
+}
+```
+
+**Branch on `code`.** It is stable. `detail` is written for a human reading a
+log and its wording can change; `title` and `status` follow `code`. Some errors
+add fields of their own, such as `requiredScope` above, and more may appear.
+
+## Invalid token
+
+`401` · `invalid_token`
+
+The `Authorization` header is missing, malformed, or names a token that is
+unknown, revoked or expired.
+
+Those cases are deliberately indistinguishable. The API will not tell you
+whether a secret was ever real, so this status cannot be used to test candidate
+tokens.
+
+## Insufficient scope
+
+`403` · `insufficient_scope`
+
+The token is valid but was not given the scope this operation needs. The
+required scope is in `requiredScope`.
+
+Scopes are fixed when a token is created, so this is not something to retry.
+Create a token with the scope it needs, or use `GET /me` to see what the current
+one holds.
+
+## Not found
+
+`404` · `not_found`
+
+There is no such resource, **or** it belongs to somebody else.
+
+Those two are one answer on purpose. If a missing form and an inaccessible form
+returned different statuses, the difference would tell you which form ids exist
+in other people's accounts.
+
+## Validation error
+
+`400` · `validation_error`
+
+The request body or query string is wrong. An `errors` array names the offending
+fields:
+
+```json
+{
+  "code": "validation_error",
+  "detail": "The request is invalid.",
+  "errors": ["name: Name must be 128 characters or fewer"]
+}
+```
+
+Also returned for a `startingAfter` cursor this API did not issue.
+
+## Quota exceeded
+
+`403` · `quota_exceeded`
+
+A plan limit stopped the request, such as the number of forms a workspace may
+hold. Free workspaces hold 10 forms; paid ones hold 100.
+
+## Conflict
+
+`409` · `conflict`
+
+The resource cannot be changed the way you asked. Today this means trying to
+delete a submission that was rejected as spam: those expire on their own and
+cannot be removed early.
+
+## Internal error
+
+`500` · `internal_error`
+
+Something broke on our side. The response deliberately carries no detail. These
+are reported to us automatically, but if one is reproducible we would like to
+hear about it.

--- a/docs/api/errors.md
+++ b/docs/api/errors.md
@@ -5,8 +5,7 @@ lang: en-US
 
 # Errors
 
-Failures are returned as [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457)
-problem details, with the content type `application/problem+json`:
+Failures are returned as [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457) problem details, with the content type `application/problem+json`:
 
 ```json
 {
@@ -19,48 +18,31 @@ problem details, with the content type `application/problem+json`:
 }
 ```
 
-**Branch on `code`.** It is stable. `detail` is written for a human reading a
-log and its wording can change; `title` and `status` follow `code`. Some errors
-add fields of their own, such as `requiredScope` above, and more may appear.
+Branch on `code`. It is stable, while `detail` is written for a human reading a log and its wording can change. Some errors add fields of their own, such as `requiredScope` above.
 
 ## Invalid token
 
 `401` · `invalid_token`
 
-The `Authorization` header is missing, malformed, or names a token that is
-unknown, revoked or expired.
-
-Those cases are deliberately indistinguishable. The API will not tell you
-whether a secret was ever real, so this status cannot be used to test candidate
-tokens.
+The `Authorization` header is missing or malformed, or the token is unknown, revoked or expired.
 
 ## Insufficient scope
 
 `403` · `insufficient_scope`
 
-The token is valid but was not given the scope this operation needs. The
-required scope is in `requiredScope`.
-
-Scopes are fixed when a token is created, so this is not something to retry.
-Create a token with the scope it needs, or use `GET /me` to see what the current
-one holds.
+The token is valid but lacks the scope this operation needs. `requiredScope` names it. Create a token with that scope, or check `GET /me` for what the current one holds.
 
 ## Not found
 
 `404` · `not_found`
 
-There is no such resource, **or** it belongs to somebody else.
-
-Those two are one answer on purpose. If a missing form and an inaccessible form
-returned different statuses, the difference would tell you which form ids exist
-in other people's accounts.
+The resource does not exist, or it belongs to another account.
 
 ## Validation error
 
 `400` · `validation_error`
 
-The request body or query string is wrong. An `errors` array names the offending
-fields:
+The request body or query string is invalid. An `errors` array names the fields:
 
 ```json
 {
@@ -76,21 +58,16 @@ Also returned for a `startingAfter` cursor this API did not issue.
 
 `403` · `quota_exceeded`
 
-A plan limit stopped the request, such as the number of forms a workspace may
-hold. Free workspaces hold 10 forms; paid ones hold 100.
+A plan limit stopped the request. Free workspaces hold 10 forms, paid ones hold 100.
 
 ## Conflict
 
 `409` · `conflict`
 
-The resource cannot be changed the way you asked. Today this means trying to
-delete a submission that was rejected as spam: those expire on their own and
-cannot be removed early.
+The resource cannot be changed that way. Deleting a submission rejected as spam returns this, since those expire on their own.
 
 ## Internal error
 
 `500` · `internal_error`
 
-Something broke on our side. The response deliberately carries no detail. These
-are reported to us automatically, but if one is reproducible we would like to
-hear about it.
+Something broke on our side. These are reported to us automatically. If one is reproducible, [let us know](https://formspark.io/support/contact).

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -55,4 +55,4 @@ Retry a write only after checking whether it landed: a repeated `POST` creates a
 
 ## Rate limits
 
-Requests are throttled per API. If you are planning something high-volume, [get in touch](https://formspark.io/support/contact) first.
+Requests are limited per IP address. Sustained bursts from one address are blocked for a period. If you are planning something high-volume, [get in touch](https://formspark.io/support/contact) first.

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -5,12 +5,7 @@ lang: en-US
 
 # API
 
-The Formspark API lets you create forms, change their settings, and read their
-submissions from your own code.
-
-It is separate from the endpoint your forms post to. `submit-form.com` receives
-submissions from browsers and needs no credentials; this API manages the forms
-behind them and always does.
+The Formspark API lets you create forms, change their settings, and read their submissions from your own code.
 
 ## Base URL
 
@@ -20,19 +15,16 @@ https://api.formspark.io/public/v1
 
 ## Authentication
 
-Every request carries an API token, created in your
-[dashboard](https://dashboard.formspark.io/account/api-tokens):
+Create an API token in your [dashboard](https://dashboard.formspark.io/account/api-tokens) and send it as a bearer token:
 
 ```sh
 curl https://api.formspark.io/public/v1/me \
   -H "Authorization: Bearer fsk_live_..."
 ```
 
-A token reaches every workspace you are a member of, limited to the scopes you
-gave it. See [API tokens](./api-tokens) for what each scope covers.
+A token reaches every workspace you are a member of, limited to its [scopes](./api-tokens).
 
-`GET /me` describes the token you are holding, which is the quickest way to
-check what a request is allowed to do:
+`GET /me` describes the token you are using:
 
 ```json
 {
@@ -45,36 +37,22 @@ check what a request is allowed to do:
 
 ## OpenAPI
 
-The API is described by an OpenAPI 3.1 document:
+The API is described by an OpenAPI 3.1 document, which you can use to generate a client:
 
 ```
 https://api.formspark.io/public/v1/openapi.json
 ```
 
-Use it to generate a typed client rather than writing one by hand. The document
-is published from the same route definitions that serve the requests, so it
-cannot drift from the API's actual behaviour.
-
 ## Versioning
 
-The version is in the path. Within `v1` we only add: new optional fields and new
-endpoints can appear at any time, so parse responses tolerantly and ignore
-fields you do not recognise.
-
-Anything that would break a working integration, such as removing a field,
-changing its type, or changing a default, means a new version rather than a
-change to this one.
+The version is in the path. Within `v1`, new optional fields and new endpoints can appear at any time, so ignore fields you do not recognise. Changes that would break a working integration ship as a new version.
 
 ## Retries
 
 `GET` requests are safe to retry.
 
-**Writes are not.** `POST` has no idempotency mechanism yet, so a retried create
-makes a second form or workspace. If a write times out, check whether it landed
-before sending it again. The `Idempotency-Key` header is reserved for this and
-is not implemented.
+Retry a write only after checking whether it landed: a repeated `POST` creates a second form or workspace.
 
 ## Rate limits
 
-Requests are throttled per API, not per token. There is no published quota yet;
-if you are planning something high-volume, get in touch first.
+Requests are throttled per API. If you are planning something high-volume, [get in touch](https://formspark.io/support/contact) first.

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,0 +1,80 @@
+---
+title: API overview
+lang: en-US
+---
+
+# API
+
+The Formspark API lets you create forms, change their settings, and read their
+submissions from your own code.
+
+It is separate from the endpoint your forms post to. `submit-form.com` receives
+submissions from browsers and needs no credentials; this API manages the forms
+behind them and always does.
+
+## Base URL
+
+```
+https://api.formspark.io/public/v1
+```
+
+## Authentication
+
+Every request carries an API token, created in your
+[dashboard](https://dashboard.formspark.io/account/api-tokens):
+
+```sh
+curl https://api.formspark.io/public/v1/me \
+  -H "Authorization: Bearer fsk_live_..."
+```
+
+A token reaches every workspace you are a member of, limited to the scopes you
+gave it. See [API tokens](./api-tokens) for what each scope covers.
+
+`GET /me` describes the token you are holding, which is the quickest way to
+check what a request is allowed to do:
+
+```json
+{
+  "name": "CI",
+  "scopes": ["forms:read", "submissions:read"],
+  "expiresAt": "2027-01-14T00:00:00.000Z",
+  "lastUsedAt": "2026-07-29T09:12:44.000Z"
+}
+```
+
+## OpenAPI
+
+The API is described by an OpenAPI 3.1 document:
+
+```
+https://api.formspark.io/public/v1/openapi.json
+```
+
+Use it to generate a typed client rather than writing one by hand. The document
+is published from the same route definitions that serve the requests, so it
+cannot drift from the API's actual behaviour.
+
+## Versioning
+
+The version is in the path. Within `v1` we only add: new optional fields and new
+endpoints can appear at any time, so parse responses tolerantly and ignore
+fields you do not recognise.
+
+Anything that would break a working integration, such as removing a field,
+changing its type, or changing a default, means a new version rather than a
+change to this one.
+
+## Retries
+
+`GET` requests are safe to retry.
+
+**Writes are not.** `POST` has no idempotency mechanism yet, so a retried create
+makes a second form or workspace. If a write times out, check whether it landed
+before sending it again. The `Idempotency-Key` header is reserved for this and
+is not implemented.
+
+## Rate limits
+
+Requests are throttled per API, not per token. There is no published quota yet;
+if you are planning something high-volume, get in touch first.

--- a/docs/api/pagination.md
+++ b/docs/api/pagination.md
@@ -17,8 +17,7 @@ List endpoints return a page and a cursor:
 }
 ```
 
-Branch on `hasMore`. When it is `true`, pass `nextCursor` back as
-`startingAfter` to get the following page:
+Branch on `hasMore`. While it is `true`, pass `nextCursor` back as `startingAfter`:
 
 ```sh
 curl "https://api.formspark.io/public/v1/forms/FORM_ID/submissions?limit=50&startingAfter=CURSOR" \
@@ -27,19 +26,7 @@ curl "https://api.formspark.io/public/v1/forms/FORM_ID/submissions?limit=50&star
 
 `limit` accepts 1 to 100 and defaults to 25.
 
-## Why cursors rather than page numbers
-
-Submissions arrive while you are reading them. With page numbers, a submission
-that arrives between two requests shifts everything down, so you see one row
-twice and miss another. A cursor points at a position in the list rather than
-counting from the start, so a walk stays correct no matter what arrives during
-it.
-
-## Treat cursors as opaque
-
-A cursor is a string to hand back, not a value to construct or decode. Its
-contents will change. A cursor this API did not issue is rejected with a
-`validation_error` rather than quietly restarting from the beginning.
+Treat a cursor as a string to hand back. Its contents will change, and a cursor this API did not issue is rejected.
 
 ## Walking every submission
 
@@ -55,6 +42,4 @@ while : ; do
 done
 ```
 
-Workspaces and forms are returned in the same envelope, but are not paginated
-today: `hasMore` is always `false` for them. Branching on `hasMore` rather than
-special-casing those endpoints means your code keeps working if that changes.
+Workspaces and forms use the same envelope, so branching on `hasMore` works everywhere.

--- a/docs/api/pagination.md
+++ b/docs/api/pagination.md
@@ -1,0 +1,60 @@
+---
+title: Pagination
+lang: en-US
+---
+
+# Pagination
+
+List endpoints return a page and a cursor:
+
+```json
+{
+  "data": [
+    { "id": "sub_1", "formId": "abc123", "data": {}, "createdAt": "..." }
+  ],
+  "hasMore": true,
+  "nextCursor": "MjAyNi0wNy0yOVQwOTo..."
+}
+```
+
+Branch on `hasMore`. When it is `true`, pass `nextCursor` back as
+`startingAfter` to get the following page:
+
+```sh
+curl "https://api.formspark.io/public/v1/forms/FORM_ID/submissions?limit=50&startingAfter=CURSOR" \
+  -H "Authorization: Bearer $FORMSPARK_TOKEN"
+```
+
+`limit` accepts 1 to 100 and defaults to 25.
+
+## Why cursors rather than page numbers
+
+Submissions arrive while you are reading them. With page numbers, a submission
+that arrives between two requests shifts everything down, so you see one row
+twice and miss another. A cursor points at a position in the list rather than
+counting from the start, so a walk stays correct no matter what arrives during
+it.
+
+## Treat cursors as opaque
+
+A cursor is a string to hand back, not a value to construct or decode. Its
+contents will change. A cursor this API did not issue is rejected with a
+`validation_error` rather than quietly restarting from the beginning.
+
+## Walking every submission
+
+```sh
+CURSOR=""
+while : ; do
+  RESPONSE=$(curl -s \
+    "https://api.formspark.io/public/v1/forms/FORM_ID/submissions?limit=100${CURSOR:+&startingAfter=$CURSOR}" \
+    -H "Authorization: Bearer $FORMSPARK_TOKEN")
+  echo "$RESPONSE" | jq -c '.data[]'
+  [ "$(echo "$RESPONSE" | jq -r '.hasMore')" = "true" ] || break
+  CURSOR=$(echo "$RESPONSE" | jq -r '.nextCursor')
+done
+```
+
+Workspaces and forms are returned in the same envelope, but are not paginated
+today: `hasMore` is always `false` for them. Branching on `hasMore` rather than
+special-casing those endpoints means your code keeps working if that changes.

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -1,0 +1,126 @@
+---
+title: API reference
+lang: en-US
+---
+
+# Reference
+
+Base URL `https://api.formspark.io/public/v1`. Every request needs an
+`Authorization: Bearer` header. The machine-readable description is at
+[`/openapi.json`](https://api.formspark.io/public/v1/openapi.json).
+
+## Token
+
+### `GET /me`
+
+Describes the current token. No scope required.
+
+## Workspaces
+
+### `GET /workspaces`
+
+Every workspace you are a member of. Scope: `workspaces:read`.
+
+### `POST /workspaces`
+
+Scope: `workspaces:write`.
+
+```sh
+curl -X POST https://api.formspark.io/public/v1/workspaces \
+  -H "Authorization: Bearer $FORMSPARK_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Acme"}'
+```
+
+### `PATCH /workspaces/{workspaceId}`
+
+Renames a workspace. Scope: `workspaces:write`.
+
+## Forms
+
+### `GET /forms?workspaceId=...`
+
+Forms in a workspace. Scope: `forms:read`.
+
+### `GET /forms/{formId}`
+
+Scope: `forms:read`.
+
+### `POST /forms`
+
+Creates a form, applying any settings sent alongside it. `workspaceId` and
+`name` are required; everything else is optional. Scope: `forms:write`.
+
+```sh
+curl -X POST https://api.formspark.io/public/v1/forms \
+  -H "Authorization: Bearer $FORMSPARK_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "workspaceId": "abc123",
+    "name": "Contact",
+    "notificationEmails": ["you@example.com"]
+  }'
+```
+
+The response contains the form's `id`. That id is what your HTML form posts to:
+
+```html
+<form action="https://submit-form.com/FORM_ID" method="POST">
+  <input type="email" name="email" />
+  <button type="submit">Send</button>
+</form>
+```
+
+### `PATCH /forms/{formId}`
+
+Applies **only the fields present in the body**. Anything you leave out keeps
+its current value, so renaming a form cannot disturb its spam protection or its
+notification emails. Scope: `forms:write`.
+
+```sh
+curl -X PATCH https://api.formspark.io/public/v1/forms/FORM_ID \
+  -H "Authorization: Bearer $FORMSPARK_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Contact us"}'
+```
+
+Sending `null` for a field clears it. Omitting it leaves it alone. The two are
+different on purpose.
+
+`notificationEmails` is replaced wholesale when present, so send the complete
+list you want rather than just the additions.
+
+### `DELETE /forms/{formId}`
+
+Deletes the form and its submissions. Scope: `forms:write`.
+
+## Submissions
+
+### `GET /forms/{formId}/submissions`
+
+Newest first, [cursor paginated](./pagination). Scope: `submissions:read`.
+
+Query parameters: `limit` (1-100, default 25), `startingAfter`, `search`.
+
+```sh
+curl "https://api.formspark.io/public/v1/forms/FORM_ID/submissions?limit=50" \
+  -H "Authorization: Bearer $FORMSPARK_TOKEN"
+```
+
+### `GET /workspaces/{workspaceId}/submissions`
+
+The same, across every form in the workspace. Scope: `submissions:read`.
+
+### `DELETE /submissions/{submissionId}`
+
+Scope: `submissions:write`.
+
+Submissions rejected as spam cannot be deleted; they expire on their own. Trying
+returns `409` with the code `conflict`.
+
+## What is not returned
+
+A form's third-party credentials, meaning its Botpoison, reCAPTCHA, hCaptcha and
+Turnstile secret keys, its Slack token and its Zapier key, are never included in
+API responses. They are readable in the dashboard only, so a leaked API token
+cannot become access to your other accounts.

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -5,15 +5,15 @@ lang: en-US
 
 # Reference
 
-Base URL `https://api.formspark.io/public/v1`. Every request needs an
-`Authorization: Bearer` header. The machine-readable description is at
-[`/openapi.json`](https://api.formspark.io/public/v1/openapi.json).
+Base URL `https://api.formspark.io/public/v1`. Every request needs an `Authorization: Bearer` header. The machine-readable description is at [`/openapi.json`](https://api.formspark.io/public/v1/openapi.json).
+
+Responses contain a form's settings and its notification emails. Its captcha secret keys, Slack token and Zapier key are available in the dashboard.
 
 ## Token
 
 ### `GET /me`
 
-Describes the current token. No scope required.
+Describes the current token. Works with any token.
 
 ## Workspaces
 
@@ -48,8 +48,7 @@ Scope: `forms:read`.
 
 ### `POST /forms`
 
-Creates a form, applying any settings sent alongside it. `workspaceId` and
-`name` are required; everything else is optional. Scope: `forms:write`.
+Creates a form, applying any settings sent with it. `workspaceId` and `name` are required. Scope: `forms:write`.
 
 ```sh
 curl -X POST https://api.formspark.io/public/v1/forms \
@@ -62,7 +61,7 @@ curl -X POST https://api.formspark.io/public/v1/forms \
   }'
 ```
 
-The response contains the form's `id`. That id is what your HTML form posts to:
+The response contains the form's `id`, which is what your HTML form posts to:
 
 ```html
 <form action="https://submit-form.com/FORM_ID" method="POST">
@@ -73,9 +72,7 @@ The response contains the form's `id`. That id is what your HTML form posts to:
 
 ### `PATCH /forms/{formId}`
 
-Applies **only the fields present in the body**. Anything you leave out keeps
-its current value, so renaming a form cannot disturb its spam protection or its
-notification emails. Scope: `forms:write`.
+Applies the fields present in the body. Fields you leave out keep their current value. Scope: `forms:write`.
 
 ```sh
 curl -X PATCH https://api.formspark.io/public/v1/forms/FORM_ID \
@@ -84,11 +81,7 @@ curl -X PATCH https://api.formspark.io/public/v1/forms/FORM_ID \
   -d '{"name":"Contact us"}'
 ```
 
-Sending `null` for a field clears it. Omitting it leaves it alone. The two are
-different on purpose.
-
-`notificationEmails` is replaced wholesale when present, so send the complete
-list you want rather than just the additions.
+Send `null` to clear a field. Send `notificationEmails` as the complete list you want, since it replaces the existing one.
 
 ### `DELETE /forms/{formId}`
 
@@ -100,7 +93,7 @@ Deletes the form and its submissions. Scope: `forms:write`.
 
 Newest first, [cursor paginated](./pagination). Scope: `submissions:read`.
 
-Query parameters: `limit` (1-100, default 25), `startingAfter`, `search`.
+Query parameters: `limit` (1 to 100, default 25), `startingAfter`, `search`.
 
 ```sh
 curl "https://api.formspark.io/public/v1/forms/FORM_ID/submissions?limit=50" \
@@ -115,12 +108,4 @@ The same, across every form in the workspace. Scope: `submissions:read`.
 
 Scope: `submissions:write`.
 
-Submissions rejected as spam cannot be deleted; they expire on their own. Trying
-returns `409` with the code `conflict`.
-
-## What is not returned
-
-A form's third-party credentials, meaning its Botpoison, reCAPTCHA, hCaptcha and
-Turnstile secret keys, its Slack token and its Zapier key, are never included in
-API responses. They are readable in the dashboard only, so a leaked API token
-cannot become access to your other accounts.
+Submissions rejected as spam expire on their own. Deleting one returns `409`.

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -2,16 +2,16 @@
 
 > A form backend. You point an HTML form at a URL and Formspark stores the
 > submissions, emails you about them, and forwards them to your other tools.
-> There is no form builder: you bring your own HTML.
+> You bring your own HTML.
 
-Two separate surfaces, and confusing them is the usual mistake:
+Two surfaces:
 
 - **submit-form.com** receives submissions from browsers. No credentials.
-- **api.formspark.io** creates and manages forms. Always needs a token.
+- **api.formspark.io** creates and manages forms. Needs a token.
 
 ## Receiving submissions
 
-Point a form at its id. That is the whole integration:
+Point a form at its id:
 
 ```html
 <form action="https://submit-form.com/YOUR_FORM_ID" method="POST">
@@ -21,22 +21,22 @@ Point a form at its id. That is the whole integration:
 </form>
 ```
 
-Every field needs a `name`, or its value is not submitted. Submitting with
-`Accept: application/json` returns JSON instead of redirecting.
+Give every field a `name`, or its value is not submitted. Submit with
+`Accept: application/json` to receive JSON instead of a redirect.
 
-Control fields are sent in the body, prefixed with an underscore. They are
-**not** form settings and cannot be configured through the API or dashboard:
+Control fields go in the body, prefixed with an underscore. They are set per
+submission, not on the form:
 
-- `_redirect` — where to send the visitor afterwards
-- `_error` — where to send them if something fails
-- `_append` — append the submission id to the redirect
-- `_email.subject`, `_email.from`, `_email.replyto` — override the notification
-- `_honeypot`, `_gotcha` — spam traps, always active
+- `_redirect` sends the visitor to a URL afterwards
+- `_error` sends them somewhere else if something fails
+- `_append` appends the submission id to the redirect
+- `_email.subject`, `_email.from`, `_email.replyto` override the notification
+- `_honeypot`, `_gotcha` are spam traps, always active
 
 ## Managing forms
 
-Base URL `https://api.formspark.io/public/v1`. Authenticate with a token created
-at https://dashboard.formspark.io/account/api-tokens:
+Base URL `https://api.formspark.io/public/v1`. Authenticate with a token from
+https://dashboard.formspark.io/account/api-tokens:
 
 ```sh
 curl https://api.formspark.io/public/v1/me \
@@ -60,16 +60,17 @@ Endpoints: `GET /me`, `GET|POST /workspaces`, `PATCH /workspaces/{id}`,
 `GET /forms/{id}/submissions`, `GET /workspaces/{id}/submissions`,
 `DELETE /submissions/{id}`.
 
-Things worth knowing before you write against it:
+Notes for writing against it:
 
-- `PATCH` applies only the fields you send. Omitting a field preserves it;
-  sending `null` clears it.
+- `PATCH` applies the fields you send and keeps the rest. Send `null` to clear
+  a field.
 - Submissions are cursor paginated. Branch on `hasMore`, pass `nextCursor` as
   `startingAfter`, treat cursors as opaque.
-- Errors are `application/problem+json`. Branch on `code`, not on wording.
-- `POST` is not idempotent. Do not blindly retry a create.
+- Errors are `application/problem+json`. Branch on `code`.
+- Check whether a `POST` landed before retrying it.
 - Scopes: `workspaces:read|write`, `forms:read|write`, `submissions:read|write`.
-- A form's captcha secrets, Slack token and Zapier key are never returned.
+- Form settings come back on the form. Captcha secret keys, the Slack token and
+  the Zapier key live in the dashboard.
 
 OpenAPI 3.1: https://api.formspark.io/public/v1/openapi.json
 

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -1,0 +1,84 @@
+# Formspark
+
+> A form backend. You point an HTML form at a URL and Formspark stores the
+> submissions, emails you about them, and forwards them to your other tools.
+> There is no form builder: you bring your own HTML.
+
+Two separate surfaces, and confusing them is the usual mistake:
+
+- **submit-form.com** receives submissions from browsers. No credentials.
+- **api.formspark.io** creates and manages forms. Always needs a token.
+
+## Receiving submissions
+
+Point a form at its id. That is the whole integration:
+
+```html
+<form action="https://submit-form.com/YOUR_FORM_ID" method="POST">
+  <input type="email" name="email" />
+  <textarea name="message"></textarea>
+  <button type="submit">Send</button>
+</form>
+```
+
+Every field needs a `name`, or its value is not submitted. Submitting with
+`Accept: application/json` returns JSON instead of redirecting.
+
+Control fields are sent in the body, prefixed with an underscore. They are
+**not** form settings and cannot be configured through the API or dashboard:
+
+- `_redirect` — where to send the visitor afterwards
+- `_error` — where to send them if something fails
+- `_append` — append the submission id to the redirect
+- `_email.subject`, `_email.from`, `_email.replyto` — override the notification
+- `_honeypot`, `_gotcha` — spam traps, always active
+
+## Managing forms
+
+Base URL `https://api.formspark.io/public/v1`. Authenticate with a token created
+at https://dashboard.formspark.io/account/api-tokens:
+
+```sh
+curl https://api.formspark.io/public/v1/me \
+  -H "Authorization: Bearer $FORMSPARK_TOKEN"
+```
+
+Create a form and read what arrives:
+
+```sh
+curl -X POST https://api.formspark.io/public/v1/forms \
+  -H "Authorization: Bearer $FORMSPARK_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"workspaceId":"WORKSPACE_ID","name":"Contact","notificationEmails":["you@example.com"]}'
+
+curl "https://api.formspark.io/public/v1/forms/FORM_ID/submissions?limit=50" \
+  -H "Authorization: Bearer $FORMSPARK_TOKEN"
+```
+
+Endpoints: `GET /me`, `GET|POST /workspaces`, `PATCH /workspaces/{id}`,
+`GET|POST /forms`, `GET|PATCH|DELETE /forms/{id}`,
+`GET /forms/{id}/submissions`, `GET /workspaces/{id}/submissions`,
+`DELETE /submissions/{id}`.
+
+Things worth knowing before you write against it:
+
+- `PATCH` applies only the fields you send. Omitting a field preserves it;
+  sending `null` clears it.
+- Submissions are cursor paginated. Branch on `hasMore`, pass `nextCursor` as
+  `startingAfter`, treat cursors as opaque.
+- Errors are `application/problem+json`. Branch on `code`, not on wording.
+- `POST` is not idempotent. Do not blindly retry a create.
+- Scopes: `workspaces:read|write`, `forms:read|write`, `submissions:read|write`.
+- A form's captcha secrets, Slack token and Zapier key are never returned.
+
+OpenAPI 3.1: https://api.formspark.io/public/v1/openapi.json
+
+## Documentation
+
+- [Installation](https://documentation.formspark.io/setup/): getting a form id
+- [Spam protection](https://documentation.formspark.io/setup/spam-protection)
+- [Redirection](https://documentation.formspark.io/customization/redirection)
+- [Feedback page](https://documentation.formspark.io/customization/feedback-page)
+- [Webhooks](https://documentation.formspark.io/integration/webhooks)
+- [API](https://documentation.formspark.io/api/)
+- [Framework examples](https://documentation.formspark.io/examples/react)


### PR DESCRIPTION
Documents the public REST API added in formspark/monorepo#69.

A new top-level **API** section rather than a page under an existing one: every other section assumes you are editing HTML, and this one is about managing forms from code.

- **Overview** — base URL, authentication, versioning, retry semantics
- **API tokens** — scopes, expiry, revocation, and keeping the secret out of argv
- **Reference** — every operation, with the `PATCH` omit-versus-null distinction spelled out
- **Pagination** — cursors, and why they are not page numbers
- **Errors** — the problem+json shape and every code

Plus `docs/public/llms.txt`, which covers the distinction agents get wrong most often: `submit-form.com` receives submissions and needs no credentials, `api.formspark.io` manages forms and always does. Formspark is currently the only product in this category without one.

**The errors page is load-bearing, not reference material.** The API returns RFC 9457 problem details whose `type` is a URI pointing at its headings, so adding an error code means adding a section here. All seven anchors were verified to resolve against the built HTML.

## Merge last

This repo deploys on push to `master`. It must land only after the API is live in production, or it documents endpoints that 404.