### PR TITLE
Document limits and plans, the paid API, and the free member cap

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -121,16 +121,6 @@ export default {
         ],
       },
       {
-        text: "API",
-        items: [
-          { text: "Overview", link: "/api/" },
-          { text: "API tokens", link: "/api/api-tokens" },
-          { text: "Reference", link: "/api/reference" },
-          { text: "Pagination", link: "/api/pagination" },
-          { text: "Errors", link: "/api/errors" },
-        ],
-      },
-      {
         text: "HTML form",
         items: [
           { text: "Form validation", link: "/html-form/form-validation" },
@@ -182,11 +172,25 @@ export default {
         ],
       },
       {
+        text: "API",
+        items: [
+          { text: "Overview", link: "/api/" },
+          { text: "API tokens", link: "/api/api-tokens" },
+          { text: "Reference", link: "/api/reference" },
+          { text: "Pagination", link: "/api/pagination" },
+          { text: "Errors", link: "/api/errors" },
+        ],
+      },
+      {
         text: "Troubleshooting",
         items: [
           {
             text: "Common issues",
             link: "/troubleshooting/common-issues",
+          },
+          {
+            text: "Limits and plans",
+            link: "/troubleshooting/limits-and-plans",
           },
           {
             text: "Email reception",

--- a/docs/api/errors.md
+++ b/docs/api/errors.md
@@ -60,6 +60,12 @@ Also returned for a `startingAfter` cursor this API did not issue.
 
 A plan limit stopped the request. Free workspaces hold 10 forms, paid ones hold 100.
 
+## Upgrade required
+
+`403` · `upgrade_required`
+
+The API is available on upgraded workspaces, and the request touched a free one. The `workspaceId` extension names it. Upgrade that workspace, or point the request at an upgraded one. See [limits and plans](/troubleshooting/limits-and-plans).
+
 ## Conflict
 
 `409` · `conflict`

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -7,6 +7,8 @@ lang: en-US
 
 The Formspark API lets you create forms, change their settings, and read their submissions from your own code.
 
+The API is available on upgraded workspaces. Listing your workspaces and reading your own token stay open on any plan, so a client can always discover which workspace qualifies. See [limits and plans](/troubleshooting/limits-and-plans).
+
 ## Base URL
 
 ```

--- a/docs/customization/feedback-page.md
+++ b/docs/customization/feedback-page.md
@@ -14,7 +14,7 @@ You can customize the look-and-feel and content of the default feedback page wit
 ### `_feedback.whitelabel`
 
 Removes all Formspark branding from the feedback page.
-You need an upgraded workspace to unlock this feature.
+You need an [upgraded workspace](/troubleshooting/limits-and-plans) to unlock this feature; on a free workspace the flag is ignored.
 
 Default value: false
 

--- a/docs/dashboard/additional-workspaces.md
+++ b/docs/dashboard/additional-workspaces.md
@@ -10,7 +10,7 @@ A workspace is a group of forms and can have one or several team members.
 Workspaces enable you to create isolated environments for your customers, companies, departments, products, etc...
 
 Note that additional user-created workspaces start with 0 submissions. All upgrades, bundles, and deals are per
-workspace.
+workspace. See [limits and plans](/troubleshooting/limits-and-plans).
 
 ## Steps
 

--- a/docs/dashboard/inviting-team-members.md
+++ b/docs/dashboard/inviting-team-members.md
@@ -9,6 +9,8 @@ You can invite members to your workspace to create forms and view submission as 
 
 When you invite team members to join your Formspark workspace, they will receive a confirmation email.
 
+Free workspaces include 5 team members. Upgraded workspaces have no practical member limit. See [limits and plans](/troubleshooting/limits-and-plans).
+
 :::tip
 You can send invitations to users who still need to create a Formspark account or to those who already have one.
 :::

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -35,8 +35,10 @@ submission, not on the form:
 
 ## Managing forms
 
-Base URL `https://api.formspark.io/public/v1`. Authenticate with a token from
-https://dashboard.formspark.io/account/api-tokens:
+Base URL `https://api.formspark.io/public/v1`. The API is available on
+upgraded workspaces; `GET /me` and `GET /workspaces` stay open on any plan,
+and a free workspace answers `403` `upgrade_required`. Authenticate with a
+token from https://dashboard.formspark.io/account/api-tokens:
 
 ```sh
 curl https://api.formspark.io/public/v1/me \
@@ -73,6 +75,15 @@ Notes for writing against it:
   the Zapier key live in the dashboard.
 
 OpenAPI 3.1: https://api.formspark.io/public/v1/openapi.json
+
+## Plans and limits
+
+One free workspace per account with 250 submissions, 10 forms, and 5 team
+members. Upgrading a workspace is a $25 one-time payment for 50,000
+submissions (no expiry, no subscription), 100 forms, unlimited team members,
+the autoresponder, feedback-page branding removal, and the REST API.
+Everything is per workspace. Details:
+https://documentation.formspark.io/troubleshooting/limits-and-plans
 
 ## Documentation
 

--- a/docs/troubleshooting/common-issues.md
+++ b/docs/troubleshooting/common-issues.md
@@ -29,7 +29,7 @@ Ensure that you are signed in with the correct email address.
 Ensure that you are connected to the right workspace: [View My Workspaces](https://dashboard.formspark.io/workspaces).
 
 Note that additional user-created workspaces start with 0 submissions. All upgrades, bundles, and deals are per
-workspace.
+workspace. See [limits and plans](/troubleshooting/limits-and-plans).
 
 ## My AJAX request returns 200 but no submission shows up
 

--- a/docs/troubleshooting/limits-and-plans.md
+++ b/docs/troubleshooting/limits-and-plans.md
@@ -1,0 +1,42 @@
+---
+title: Limits and plans
+lang: en-US
+---
+
+# Limits and plans
+
+Every Formspark account starts with one free workspace. Upgrading is a one-time payment per workspace, not a subscription: a bundle of submissions plus the paid features, valid until you have spent them.
+
+## What each plan includes
+
+|                             | Free      | Upgraded                                                      |
+| --------------------------- | --------- | ------------------------------------------------------------- |
+| Submissions                 | 250       | 50,000 per bundle                                             |
+| Forms                       | 10        | 100                                                           |
+| Team members                | 5         | Unlimited                                                     |
+| Submission archive          | Forever   | Forever                                                       |
+| Spam protection             | Included  | Included                                                      |
+| Webhooks, Slack and Zapier  | Included  | Included                                                      |
+| Exports                     | Included  | Included                                                      |
+| Autoresponder               | No        | [Included](/dashboard/autoresponder)                          |
+| Removing Formspark branding | No        | [Included](/customization/feedback-page#_feedback-whitelabel) |
+| REST API                    | No        | [Included](/api/)                                             |
+| Support                     | Community | Customer assistance team                                      |
+
+## How submissions are counted
+
+Every accepted submission spends one submission from its workspace. Submissions rejected as spam do not count against your total.
+
+Submission bundles do not expire. Buy one when you need it, spend it at your pace, and buy another when it runs out. There are no automatic payments.
+
+## Running out of submissions
+
+Formspark does not cut you off at exactly zero. There is a small buffer past the end of your submissions, and recent submissions that arrive beyond it are held back rather than discarded. Purchasing a new bundle releases the held submissions straight into your inbox.
+
+## Everything is per workspace
+
+Upgrades, bundles, and deals apply to a single workspace. Additional user-created workspaces start with 0 submissions and can be upgraded separately. See [additional workspaces](/dashboard/additional-workspaces).
+
+## Team members
+
+Free workspaces include 5 team members. Upgraded workspaces have no practical member limit. Members who joined before a limit applied always keep their access; limits only affect new invitations. See [inviting team members](/dashboard/inviting-team-members).


### PR DESCRIPTION
Companion to formspark/monorepo#75 - merge after that PR deploys.

- New canonical Limits and plans page under Troubleshooting (quota buffer described qualitatively, no exact numbers).
- API overview and errors document the paid requirement and the new `upgrade_required` code.
- Whitelabel note now says the flag is ignored on free workspaces.
- Free member cap noted on Inviting team members; cross-links from additional-workspaces and common-issues.
- Sidebar: API group moved below Integrations.
- llms.txt updated with plans, limits, and the API gate.