### PR TITLE
Document the native Google Sheets and Notion integrations

### DIFF
--- a/docs/integration/google-sheets.md
+++ b/docs/integration/google-sheets.md
@@ -5,31 +5,31 @@ lang: en-US
 
 # Google Sheets
 
-Formspark does not connect to Google Sheets directly. The recommended path is to use Zapier or Make as a bridge. For developers, a Google Apps Script webhook is also an option.
+Formspark can send every submission from your form straight into a Google Sheets spreadsheet, created automatically and kept up to date.
 
-## Via Zapier
+Google Sheets is available on all paid workspaces.
 
-1. Set up the Formspark [Zapier integration](/integration/zapier).
-2. In your Zap, select `New Submission` as the trigger.
-3. Add `Google Sheets` as the action and choose `Create Spreadsheet Row`.
-4. Map your form fields to the matching spreadsheet columns.
+## Connecting
 
-## Via Make
+1. Open your form's settings and find the `Google Sheets` card under `Integrations`.
+2. Click `Connect Google Sheets` and sign in with the Google account that should own the spreadsheet.
+3. Approve the requested access. Formspark only requests permission to the spreadsheets it creates itself, not the rest of your Google Drive.
+4. Formspark creates a new spreadsheet named after your form and starts sending submissions to it.
 
-1. Set up the Formspark [Make integration](/integration/make).
-2. In your scenario, select `Formspark` → `New Submission` as the trigger.
-3. Add a `Google Sheets` → `Add a Row` module.
-4. Map your form fields to the matching spreadsheet columns.
+You do not pick an existing spreadsheet: Formspark always creates a new one.
 
-The free tier of both Zapier and Make is sufficient for typical low-volume contact forms.
+## What gets sent
 
-## Via webhook (Google Apps Script)
+Each submission is appended as a new row. The header row starts with `Submitted at`, followed by one column per field name your form submits. If a later submission includes a field the sheet has not seen before, Formspark adds a new column for it; existing columns and rows are never reordered or rewritten.
 
-If you'd rather skip a third-party automation tool, you can deploy a Google Apps Script as a web app and use its URL as your form's webhook.
+## If syncing pauses
 
-1. Open your spreadsheet and go to `Extensions` → `Apps Script`.
-2. Write a `doPost(e)` function that appends `e.postData.contents` to the active sheet.
-3. Deploy the script as a web app with access set to `Anyone`.
-4. Paste the deployment URL into your form's `Webhook URL` field.
+::: warning
+If a connection keeps failing, for example because the spreadsheet was deleted, Formspark pauses syncing for that form. Retry from the card, or reconnect if the spreadsheet itself is gone.
+:::
 
-[Check this page](/integration/webhooks) to learn more about webhooks.
+## Disconnecting
+
+Click `Disconnect Google Sheets` in the same card to stop sending submissions. Disconnecting does not delete the spreadsheet, it stays in your Google Drive with whatever rows were already added; Formspark simply stops writing to it.
+
+To send submissions to a different spreadsheet, disconnect and connect again. This creates a new spreadsheet, it does not reuse the old one.

--- a/docs/integration/notion.md
+++ b/docs/integration/notion.md
@@ -5,22 +5,31 @@ lang: en-US
 
 # Notion
 
-Formspark does not connect to Notion directly. The recommended path is to use Zapier or Make as a bridge.
+Formspark can send every submission from your form straight into a Notion database, created automatically inside a page you share during setup.
 
-## Via Zapier
+Notion is available on all paid workspaces.
 
-1. Set up the Formspark [Zapier integration](/integration/zapier).
-2. In your Zap, select `New Submission` as the trigger.
-3. Add `Notion` as the action and choose `Create Database Item`.
-4. Map your form fields to the matching Notion database properties.
+## Connecting
 
-## Via Make
+1. Open your form's settings and find the `Notion` card under `Integrations`.
+2. Click `Connect Notion` and sign in to the Notion workspace you want to use.
+3. On Notion's own consent screen, select the page you want to share with Formspark, then confirm access.
+4. Formspark creates a new database as a child of the page you shared and starts sending submissions to it.
 
-1. Set up the Formspark [Make integration](/integration/make).
-2. In your scenario, select `Formspark` → `New Submission` as the trigger.
-3. Add a `Notion` → `Create a Database Item` module.
-4. Map your form fields to the matching Notion database properties.
+You do not pick an existing database: Formspark always creates a new one, as a child of whichever page you shared.
 
-## A note on direct webhooks
+## What gets sent
 
-It is possible to point your form's `Webhook URL` directly at Notion's API, but Notion enforces a 3-requests-per-second rate limit and returns submission errors that need to be retried. Zapier and Make handle this for you, so we recommend going through one of them unless you are comfortable building your own retry layer.
+Each submission becomes a new entry in the database, with one property per field name your form submits.
+
+## If no page is shared
+
+::: warning
+Sharing a page happens on Notion's own consent screen, not in a Formspark setting: Formspark cannot create a database anywhere you have not explicitly shared with it. If you get through the consent screen without selecting a page, the connection fails. Reconnect from your form's settings and make sure you select a page to share before confirming.
+:::
+
+## Disconnecting
+
+Click `Disconnect Notion` in the same card to stop sending submissions. Disconnecting does not delete the database or the page it lives in, they stay in your Notion workspace with whatever entries were already added; Formspark simply stops writing to it.
+
+To send submissions to a different page, disconnect and connect again, and share a different page this time.


### PR DESCRIPTION
## What

Rewrites `docs/integration/google-sheets.md` and `docs/integration/notion.md`, which previously described using Zapier or Make as a bridge, to instead document the new native per-form OAuth integrations: connect from the form's Settings under Integrations, Formspark creates a new spreadsheet or database automatically, submissions land as rows or entries, available on paid workspaces, disconnect from the same card.

## Navigation

Both pages already had sidebar entries in `docs/.vitepress/config.js` under the Integrations group (added when the files were first created as Zapier/Make-bridge pages), so no navigation changes were needed. The content rewrite is the only change.

## Not yet live

This documents features still in development on `formspark/monorepo`:

- `feat/google-sheets-integration`
- `feat/notion-integration`

Neither branch is merged. Do not merge or publish this PR until both integrations have shipped, otherwise the docs site will describe a feature customers cannot use yet.

## Verification

- `npm run build` (vitepress build) completes cleanly, both pages render.
- `npx prettier --check` passes on both files.
- No screenshots were added: the existing integration docs (`slack.md`) reference screenshots of the live UI, but there is no live UI yet for these two connect flows to capture. Someone with access to the shipped feature should add screenshots in a follow-up once it's live.