### PR TITLE
Correct the API docs, sweep for typos, add three examples

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -141,6 +141,7 @@ export default {
         items: [
           { text: "AJAX submissions", link: "/examples/ajax" },
           { text: "Alpine.js", link: "/examples/alpinejs" },
+          { text: "Analog", link: "/examples/analog" },
           { text: "Angular", link: "/examples/angular" },
           { text: "Astro", link: "/examples/astro" },
           { text: "Eleventy", link: "/examples/eleventy" },
@@ -155,6 +156,8 @@ export default {
           { text: "Qwik", link: "/examples/qwik" },
           { text: "React", link: "/examples/react" },
           { text: "React Native", link: "/examples/react-native" },
+          { text: "Remix", link: "/examples/remix" },
+          { text: "SolidStart", link: "/examples/solidstart" },
           { text: "Svelte", link: "/examples/svelte" },
           { text: "SvelteKit", link: "/examples/sveltekit" },
           { text: "VitePress", link: "/examples/vitepress" },

--- a/docs/api/errors.md
+++ b/docs/api/errors.md
@@ -9,7 +9,7 @@ Failures are returned as [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457) prob
 
 ```json
 {
-  "type": "https://documentation.formspark.io/api/errors#insufficient-scope",
+  "type": "https://documentation.formspark.io/api/errors.html#insufficient-scope",
   "title": "Insufficient scope",
   "status": 403,
   "detail": "This token has forms:read; forms:write is required.",
@@ -19,6 +19,8 @@ Failures are returned as [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457) prob
 ```
 
 Branch on `code`. It is stable, while `detail` is written for a human reading a log and its wording can change. Some errors add fields of their own, such as `requiredScope` above.
+
+`type` points at the section for that code on this page: the code with its underscores replaced by hyphens, as an anchor.
 
 ## Invalid token
 
@@ -70,7 +72,7 @@ The API is available on upgraded workspaces, and the request touched a free one.
 
 `409` · `conflict`
 
-The resource cannot be changed that way. Deleting a submission rejected as spam returns this, since those expire on their own.
+The resource cannot be changed that way. Deleting a submission that was quarantined as spam returns this: quarantined submissions expire on their own and cannot be deleted early.
 
 ## Internal error
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -47,7 +47,7 @@ https://api.formspark.io/public/v1/openapi.json
 
 ## Versioning
 
-The version is in the path. Within `v1`, new optional fields and new endpoints can appear at any time, so ignore fields you do not recognise. Changes that would break a working integration ship as a new version.
+The version is in the path. Within `v1`, new optional fields and new endpoints can appear at any time, so ignore fields you do not recognize. Changes that would break a working integration ship as a new version.
 
 ## Retries
 

--- a/docs/api/pagination.md
+++ b/docs/api/pagination.md
@@ -10,7 +10,7 @@ List endpoints return a page and a cursor:
 ```json
 {
   "data": [
-    { "id": "sub_1", "formId": "abc123", "data": {}, "createdAt": "..." }
+    { "id": "sub_1", "formId": "your-form-id", "data": {}, "createdAt": "..." }
   ],
   "hasMore": true,
   "nextCursor": "MjAyNi0wNy0yOVQwOTo..."
@@ -20,13 +20,15 @@ List endpoints return a page and a cursor:
 Branch on `hasMore`. While it is `true`, pass `nextCursor` back as `startingAfter`:
 
 ```sh
-curl "https://api.formspark.io/public/v1/forms/FORM_ID/submissions?limit=50&startingAfter=CURSOR" \
+curl "https://api.formspark.io/public/v1/forms/your-form-id/submissions?limit=50&startingAfter=$CURSOR" \
   -H "Authorization: Bearer $FORMSPARK_TOKEN"
 ```
 
 `limit` accepts 1 to 100 and defaults to 25.
 
-Treat a cursor as a string to hand back. Its contents will change, and a cursor this API did not issue is rejected.
+## Cursors are opaque
+
+A cursor is a string to hand back untouched. Do not build one, decode one, or derive one from a submission's `id` or `createdAt`: what a cursor encodes is an implementation detail and it will change. A cursor this API did not issue, or one that has been modified, comes back as a `400` [`validation_error`](./errors#validation-error).
 
 ## Walking every submission
 
@@ -34,7 +36,7 @@ Treat a cursor as a string to hand back. Its contents will change, and a cursor 
 CURSOR=""
 while : ; do
   RESPONSE=$(curl -s \
-    "https://api.formspark.io/public/v1/forms/FORM_ID/submissions?limit=100${CURSOR:+&startingAfter=$CURSOR}" \
+    "https://api.formspark.io/public/v1/forms/your-form-id/submissions?limit=100${CURSOR:+&startingAfter=$CURSOR}" \
     -H "Authorization: Bearer $FORMSPARK_TOKEN")
   echo "$RESPONSE" | jq -c '.data[]'
   [ "$(echo "$RESPONSE" | jq -r '.hasMore')" = "true" ] || break

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -7,7 +7,7 @@ lang: en-US
 
 Base URL `https://api.formspark.io/public/v1`. Every request needs an `Authorization: Bearer` header. The machine-readable description is at [`/openapi.json`](https://api.formspark.io/public/v1/openapi.json).
 
-Responses contain a form's settings and its notification emails. Its captcha secret keys, Slack token and Zapier key are available in the dashboard.
+Responses contain a form's settings and its notification emails. Captcha secret keys, the Slack token and the Zapier key are never returned; they stay in the dashboard.
 
 ## Token
 
@@ -19,7 +19,9 @@ Describes the current token. Works with any token.
 
 ### `GET /workspaces`
 
-Every workspace you are a member of. Scope: `workspaces:read`.
+Every workspace you are a member of, [cursor paginated](./pagination). Scope: `workspaces:read`.
+
+Query parameters: `limit` (1 to 100, default 25), `startingAfter`.
 
 ### `POST /workspaces`
 
@@ -40,7 +42,9 @@ Renames a workspace. Scope: `workspaces:write`.
 
 ### `GET /forms?workspaceId=...`
 
-Forms in a workspace. Scope: `forms:read`.
+Forms in a workspace, [cursor paginated](./pagination). Scope: `forms:read`.
+
+Query parameters: `limit` (1 to 100, default 25), `startingAfter`.
 
 ### `GET /forms/{formId}`
 
@@ -55,7 +59,7 @@ curl -X POST https://api.formspark.io/public/v1/forms \
   -H "Authorization: Bearer $FORMSPARK_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
-    "workspaceId": "abc123",
+    "workspaceId": "your-workspace-id",
     "name": "Contact",
     "notificationEmails": ["you@example.com"]
   }'
@@ -64,7 +68,7 @@ curl -X POST https://api.formspark.io/public/v1/forms \
 The response contains the form's `id`, which is what your HTML form posts to:
 
 ```html
-<form action="https://submit-form.com/FORM_ID" method="POST">
+<form action="https://submit-form.com/your-form-id" method="POST">
   <input type="email" name="email" />
   <button type="submit">Send</button>
 </form>
@@ -75,7 +79,7 @@ The response contains the form's `id`, which is what your HTML form posts to:
 Applies the fields present in the body. Fields you leave out keep their current value. Scope: `forms:write`.
 
 ```sh
-curl -X PATCH https://api.formspark.io/public/v1/forms/FORM_ID \
+curl -X PATCH https://api.formspark.io/public/v1/forms/your-form-id \
   -H "Authorization: Bearer $FORMSPARK_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"name":"Contact us"}'
@@ -87,6 +91,33 @@ Send `null` to clear a field. Send `notificationEmails` as the complete list you
 
 Deletes the form and its submissions. Scope: `forms:write`.
 
+### Form settings
+
+`POST /forms` and `PATCH /forms/{formId}` accept a form's settings, with a few restrictions. Anything the API rejects comes back as a [`validation_error`](./errors#validation-error).
+
+#### `spamProtection`
+
+Accepts one of four values:
+
+| Value                 | Provider     |
+| --------------------- | ------------ |
+| `BOTPOISON`           | Botpoison    |
+| `GOOGLE_RECAPTCHA_V2` | reCAPTCHA v2 |
+| `HCAPTCHA`            | hCaptcha     |
+| `TURNSTILE`           | Turnstile    |
+
+No other value is accepted, and the automatic spam filtering that screens every submission is not configurable.
+
+The provider's secret key is not part of the API. Store it in the dashboard first, then switch the form over: selecting a provider whose secret key is not already stored is rejected. See [spam protection](/setup/spam-protection).
+
+#### `webhookUrl`
+
+Must be an `http` or `https` URL. See [webhooks](/integration/webhooks).
+
+#### `notificationEmails`
+
+A form accepts at most 10 notification emails. Since the list you send replaces the existing one, read the current list back first if you are adding to it rather than replacing it.
+
 ## Submissions
 
 ### `GET /forms/{formId}/submissions`
@@ -96,7 +127,7 @@ Newest first, [cursor paginated](./pagination). Scope: `submissions:read`.
 Query parameters: `limit` (1 to 100, default 25), `startingAfter`, `search`.
 
 ```sh
-curl "https://api.formspark.io/public/v1/forms/FORM_ID/submissions?limit=50" \
+curl "https://api.formspark.io/public/v1/forms/your-form-id/submissions?limit=50" \
   -H "Authorization: Bearer $FORMSPARK_TOKEN"
 ```
 
@@ -108,4 +139,4 @@ The same, across every form in the workspace. Scope: `submissions:read`.
 
 Scope: `submissions:write`.
 
-Submissions rejected as spam expire on their own. Deleting one returns `409`.
+Submissions rejected as spam expire on their own and cannot be deleted early. Deleting one returns a [`conflict`](./errors#conflict).

--- a/docs/customization/custom-routing.md
+++ b/docs/customization/custom-routing.md
@@ -8,10 +8,16 @@ lang: en-US
 You can use JavaScript to dynamically select a form endpoint.
 
 Using this technique, you can use a drop-down to dynamically route submissions to a specific team, department, inbox,
-webhook, etc...
+webhook, etc.
+
+Each option points at a form of its own, so create one form per destination and swap in its action URL below.
 
 ```html
-<form id="my-form" action="https://submit-form.com/sales-form-id" method="POST">
+<form
+  id="my-form"
+  action="https://submit-form.com/your-sales-form-id"
+  method="POST"
+>
   <label for="department">Department</label>
   <select id="department" onchange="onChange(this)">
     <option value="sales" selected>Sales</option>
@@ -29,13 +35,13 @@ webhook, etc...
     let action;
     switch (event.value) {
       case "sales":
-        action = "https://submit-form.com/sales-form-id";
+        action = "https://submit-form.com/your-sales-form-id";
         break;
       case "marketing":
-        action = "https://submit-form.com/marketing-form-id";
+        action = "https://submit-form.com/your-marketing-form-id";
         break;
       case "hr":
-        action = "https://submit-form.com/hr-form-id";
+        action = "https://submit-form.com/your-hr-form-id";
         break;
     }
     document.getElementById("my-form").action = action;

--- a/docs/customization/notification-email.md
+++ b/docs/customization/notification-email.md
@@ -59,9 +59,9 @@ Create a hidden input with the name `_email.template.footer` and the value `fals
 
 You can go beyond these options and design the notification email in a visual template editor, built in partnership with [Postcraft](https://postcraft.io/).
 
-[Check this page](/dashboard/email-notification-settings.html#custom-templates) to learn more about custom email
+[Check this page](/dashboard/email-notification-settings#custom-templates) to learn more about custom email
 templates.
 
 ## Autoresponder
 
-Notification emails go to you; the [autoresponder](/dashboard/autoresponder.html) sends a confirmation email to the person who submitted your form.
+Notification emails go to you; the [autoresponder](/dashboard/autoresponder) sends a confirmation email to the person who submitted your form.

--- a/docs/customization/redirection.md
+++ b/docs/customization/redirection.md
@@ -65,7 +65,7 @@ automatically be inherited.
 
 This is only possible with JavaScript/AJAX.
 
-Formspark has excellent AJAX support, [learn more about it here](/examples/ajax.html).
+Formspark has excellent AJAX support, [learn more about it here](/examples/ajax).
 
 ### Returning to the same page (after leaving it)
 

--- a/docs/dashboard/additional-workspaces.md
+++ b/docs/dashboard/additional-workspaces.md
@@ -7,7 +7,7 @@ lang: en-US
 
 A workspace is a group of forms and can have one or several team members.
 
-Workspaces enable you to create isolated environments for your customers, companies, departments, products, etc...
+Workspaces enable you to create isolated environments for your customers, companies, departments, products, etc.
 
 Note that additional user-created workspaces start with 0 submissions. All upgrades, bundles, and deals are per
 workspace. See [limits and plans](/troubleshooting/limits-and-plans).

--- a/docs/dashboard/autoresponder.md
+++ b/docs/dashboard/autoresponder.md
@@ -7,7 +7,7 @@ lang: en-US
 
 The autoresponder automatically sends a confirmation email to the person who submitted your form.
 
-The autoresponder is available on all paid workspaces.
+The autoresponder is available on [upgraded workspaces](/troubleshooting/limits-and-plans).
 
 ## Enabling the autoresponder
 

--- a/docs/dashboard/inviting-team-members.md
+++ b/docs/dashboard/inviting-team-members.md
@@ -5,7 +5,7 @@ lang: en-US
 
 # Inviting team members
 
-You can invite members to your workspace to create forms and view submission as a team.
+You can invite members to your workspace to create forms and view submissions as a team.
 
 When you invite team members to join your Formspark workspace, they will receive a confirmation email.
 

--- a/docs/examples/alpinejs.md
+++ b/docs/examples/alpinejs.md
@@ -74,7 +74,7 @@ article: [Building an AJAX form with Alpine.js](https://technotrampoline.com/art
 
 ## With success and error states
 
-Tracks three states (`idle`, `success`, `error`) so you can show a thank-you message on success or an inline error on failure without leaving the page.
+Tracks the submission state (`idle`, `loading`, `success`, `error`) so you can show a thank-you message on success or an inline error on failure without leaving the page.
 
 ```html
 <!DOCTYPE html>

--- a/docs/examples/analog.md
+++ b/docs/examples/analog.md
@@ -1,0 +1,88 @@
+---
+title: Analog
+lang: en-US
+---
+
+# Analog
+
+Analog is the full-stack meta-framework for Angular. Its pages are ordinary
+standalone Angular components, so the [Angular](/examples/angular) patterns
+apply here too.
+
+## HTML form
+
+The action URL can be used directly, so a page that only needs to collect a
+submission needs no component logic.
+
+```ts
+// src/app/pages/contact.page.ts
+import { Component } from "@angular/core";
+
+@Component({
+  standalone: true,
+  template: `
+    <form method="POST" action="https://submit-form.com/your-form-id">
+      <label>
+        <span>Message</span>
+        <textarea name="message"></textarea>
+      </label>
+      <button type="submit">Send</button>
+    </form>
+  `,
+})
+export default class ContactPage {}
+```
+
+A page component is exported as `default`, which is how Analog's file-based
+router picks it up.
+
+## Fetch
+
+Keeps the submission on the page so you can disable the form while it is in
+flight and show your own confirmation.
+
+```ts
+// src/app/pages/contact.page.ts
+import { Component } from "@angular/core";
+import { FormsModule } from "@angular/forms";
+
+const FORMSPARK_ACTION_URL = "https://submit-form.com/your-form-id";
+
+@Component({
+  standalone: true,
+  imports: [FormsModule],
+  template: `
+    <form (ngSubmit)="onSubmit()">
+      <label>
+        <span>Message</span>
+        <textarea name="message" [(ngModel)]="message"></textarea>
+      </label>
+      <button type="submit" [disabled]="submitting">Send</button>
+    </form>
+  `,
+})
+export default class ContactPage {
+  message = "";
+  submitting = false;
+
+  async onSubmit() {
+    this.submitting = true;
+    try {
+      await fetch(FORMSPARK_ACTION_URL, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+        body: JSON.stringify({ message: this.message }),
+      });
+      this.message = "";
+    } finally {
+      this.submitting = false;
+    }
+  }
+}
+```
+
+`[(ngModel)]` requires the control to carry a `name` attribute when it sits
+inside a form.

--- a/docs/examples/nuxtjs.md
+++ b/docs/examples/nuxtjs.md
@@ -43,6 +43,8 @@ const onSubmit = async () => {
 
 ## Fetch
 
+`$fetch` is Nuxt's built-in HTTP client, so the body is passed as an object rather than a JSON string.
+
 ```vue
 <script setup>
 import { ref } from "vue";

--- a/docs/examples/remix.md
+++ b/docs/examples/remix.md
@@ -1,0 +1,125 @@
+---
+title: Remix
+lang: en-US
+---
+
+# Remix
+
+## Route action
+
+An `action` runs on the server, so the submission works before the page has
+hydrated and keeps working with JavaScript disabled.
+
+```jsx
+// app/routes/contact.jsx
+import { redirect } from "@remix-run/node";
+import { Form } from "@remix-run/react";
+
+const FORMSPARK_ACTION_URL = "https://submit-form.com/your-form-id";
+
+export async function action({ request }) {
+  const formData = await request.formData();
+  await fetch(FORMSPARK_ACTION_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify(Object.fromEntries(formData)),
+  });
+  return redirect("/thanks");
+}
+
+export default function ContactPage() {
+  return (
+    <Form method="post">
+      <label>
+        <span>Message</span>
+        <textarea name="message" required />
+      </label>
+      <button type="submit">Send</button>
+    </Form>
+  );
+}
+```
+
+Remix's `<Form>` submits without a full page load once hydrated, and falls back
+to a normal browser submission before that.
+
+### Disabling the button while submitting
+
+`useNavigation` reports the state of the in-flight submission.
+
+```jsx
+// app/routes/contact.jsx
+import { Form, useNavigation } from "@remix-run/react";
+
+export default function ContactPage() {
+  const navigation = useNavigation();
+  const submitting = navigation.state === "submitting";
+
+  return (
+    <Form method="post">
+      <label>
+        <span>Message</span>
+        <textarea name="message" required />
+      </label>
+      <button type="submit" disabled={submitting}>
+        {submitting ? "Sending..." : "Send"}
+      </button>
+    </Form>
+  );
+}
+```
+
+## use-formspark
+
+:::tip
+Check out our official React hooks: [use-formspark](https://github.com/formspark/use-formspark).
+:::
+
+Submits from the browser instead, so you can stay on the page and render your
+own confirmation.
+
+```jsx
+// app/routes/contact.jsx
+import { useState } from "react";
+import { useFormspark } from "@formspark/use-formspark";
+
+const FORMSPARK_FORM_ID = "your-form-id";
+
+export default function ContactPage() {
+  const [submit, submitting] = useFormspark({
+    formId: FORMSPARK_FORM_ID,
+  });
+
+  const [message, setMessage] = useState("");
+  const [sent, setSent] = useState(false);
+
+  const onSubmit = async (e) => {
+    e.preventDefault();
+    await submit({ message });
+    setMessage("");
+    setSent(true);
+  };
+
+  if (sent) {
+    return <p>Thanks! We received your message.</p>;
+  }
+
+  return (
+    <form onSubmit={onSubmit}>
+      <label>
+        <span>Message</span>
+        <textarea
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+        />
+      </label>
+      <button type="submit" disabled={submitting}>
+        Send
+      </button>
+    </form>
+  );
+}
+```

--- a/docs/examples/solidstart.md
+++ b/docs/examples/solidstart.md
@@ -1,0 +1,79 @@
+---
+title: SolidStart
+lang: en-US
+---
+
+# SolidStart
+
+## HTML form
+
+A plain form posts straight to your action URL, so it needs no client
+JavaScript and works before the page has hydrated.
+
+```jsx
+// src/routes/contact.jsx
+const FORMSPARK_ACTION_URL = "https://submit-form.com/your-form-id";
+
+export default function ContactPage() {
+  return (
+    <form method="post" action={FORMSPARK_ACTION_URL}>
+      <label>
+        <span>Message</span>
+        <textarea name="message" required />
+      </label>
+      <button type="submit">Send</button>
+    </form>
+  );
+}
+```
+
+## Fetch
+
+Solid's signals are read as functions, and text inputs report changes through
+`onInput` rather than `onChange`.
+
+```jsx
+// src/routes/contact.jsx
+import { createSignal } from "solid-js";
+
+const FORMSPARK_ACTION_URL = "https://submit-form.com/your-form-id";
+
+export default function ContactPage() {
+  const [message, setMessage] = createSignal("");
+  const [submitting, setSubmitting] = createSignal(false);
+
+  const onSubmit = async (e) => {
+    e.preventDefault();
+    setSubmitting(true);
+    try {
+      await fetch(FORMSPARK_ACTION_URL, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+        body: JSON.stringify({ message: message() }),
+      });
+      setMessage("");
+      alert("Form submitted");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={onSubmit}>
+      <label>
+        <span>Message</span>
+        <textarea
+          value={message()}
+          onInput={(e) => setMessage(e.currentTarget.value)}
+        />
+      </label>
+      <button type="submit" disabled={submitting()}>
+        Send
+      </button>
+    </form>
+  );
+}
+```

--- a/docs/html-form/drop-down-list.md
+++ b/docs/html-form/drop-down-list.md
@@ -38,7 +38,7 @@ Use the `multiple` attribute to specify whether multiple options can be selected
 ```
 
 ::: tip
-When a `multiple` select has nothing selected, the field is omitted from the submission entirely — the key will not appear in your data.
+When a `multiple` select has nothing selected, the field is omitted from the submission entirely, so the key will not appear in your data.
 :::
 
 ## Grouped options

--- a/docs/html-form/form-styling.md
+++ b/docs/html-form/form-styling.md
@@ -189,4 +189,4 @@ When you submit via AJAX, you control the post-submission UI yourself. A common 
 
 - [Bootstrap](https://getbootstrap.com/)
 - [Tailwind CSS](https://tailwindcss.com/)
-- [Pico CSS](https://picocss.com/) — minimal, semantic, no classes required.
+- [Pico CSS](https://picocss.com/): minimal, semantic, no classes required.

--- a/docs/html-form/form-validation.md
+++ b/docs/html-form/form-validation.md
@@ -5,7 +5,7 @@ lang: en-US
 
 # Form validation
 
-We recommend using HTML5's built-in validation. It is very rich these days, and has good browser support.
+We recommend using HTML5's built-in validation. It is rich and has good browser support.
 
 ::: warning
 Formspark performs no server-side validation. Validate your inputs client-side before submission to avoid storing malformed data.

--- a/docs/integration/google-sheets.md
+++ b/docs/integration/google-sheets.md
@@ -7,7 +7,7 @@ lang: en-US
 
 Formspark can send every submission from your form straight into a Google Sheets spreadsheet, created automatically and kept up to date.
 
-Google Sheets is available on all paid workspaces.
+Google Sheets is available on [upgraded workspaces](/troubleshooting/limits-and-plans).
 
 ## Connecting
 

--- a/docs/integration/notion.md
+++ b/docs/integration/notion.md
@@ -7,7 +7,7 @@ lang: en-US
 
 Formspark can send every submission from your form straight into a Notion database, created automatically inside a page you share during setup.
 
-Notion is available on all paid workspaces.
+Notion is available on [upgraded workspaces](/troubleshooting/limits-and-plans).
 
 ## Connecting
 

--- a/docs/integration/utm-parameters.md
+++ b/docs/integration/utm-parameters.md
@@ -8,7 +8,7 @@ lang: en-US
 Marketers use UTM parameters to track the effectiveness of online campaigns across traffic sources and publishing media.
 The parameters identify the campaign that refers traffic to a specific website and can be parsed by analytics tools and used to populate reports.
 
-Copying these parameters and injecting them into your form submissions manually is tedious and error-prone, we built Formtrack to automate this process.
+Copying these parameters and injecting them into your form submissions manually is tedious and error-prone, so we built Formtrack to automate this process.
 
 ## Installation & usage
 

--- a/docs/integration/webhooks.md
+++ b/docs/integration/webhooks.md
@@ -21,7 +21,7 @@ Given the following form:
 ```html
 <form action="https://submit-form.com/your-form-id">
   <input type="text" name="email" />
-  <textarea name="description" />
+  <textarea name="message"></textarea>
   <button type="submit">Send</button>
 </form>
 ```
@@ -39,7 +39,7 @@ The body of the POST request will look as follows:
 
 - Your endpoint should accept POST requests.
 - Your endpoint should be able to parse a JSON object.
-- Your endpoint's url length should not exceed 512 characters.
+- Your endpoint's URL should not exceed 512 characters.
 
 To preview what the webhook requests look like before pointing them at your own server, use a public inspection service such as [httphq.com](https://httphq.com). Paste the temporary URL it gives you into the `Webhook URL` field and submit your form once.
 

--- a/docs/setup/file-uploads.md
+++ b/docs/setup/file-uploads.md
@@ -13,8 +13,8 @@ The example below uses Uploadcare. Any provider that returns a public URL after 
 
 ## Uploadcare
 
-Create a free Uploadcare account at [https://uploadcare.com/](https://uploadcare.com/), the free tier of Uploadcare
-gives you 3000 uploads per month
+Create a free Uploadcare account at [https://uploadcare.com/](https://uploadcare.com/). Their free tier gives you 3000
+uploads per month.
 
 Want to upload non-image files? You can add a payment method to your Uploadcare account without having to leave their
 free plan.
@@ -44,7 +44,7 @@ the `data-public-key` attribute.
 
 ```html
 <!-- Photo -->
-<label for="photo">Name</label>
+<label for="photo">Photo</label>
 <input
   type="hidden"
   id="photo"
@@ -80,7 +80,7 @@ Final code:
       <input type="text" id="name" name="name" placeholder="Name" required="" />
 
       <!-- Photo -->
-      <label for="photo">Name</label>
+      <label for="photo">Photo</label>
       <input
         type="hidden"
         id="photo"
@@ -97,7 +97,7 @@ Final code:
 
 ## Alternatives
 
-- [Cloudinary](https://cloudinary.com/) — image and video focused, generous free tier.
-- [Filestack](https://www.filestack.com/) — drop-in widget similar to Uploadcare.
-- [Bunny Storage](https://bunny.net/storage/) — cheap edge storage with a simple HTTP API.
-- [Amazon S3 pre-signed URLs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-presigned-url.html) — generate an upload URL from your own backend, then submit the resulting file URL to Formspark.
+- [Cloudinary](https://cloudinary.com/): image and video focused, generous free tier.
+- [Filestack](https://www.filestack.com/): drop-in widget similar to Uploadcare.
+- [Bunny Storage](https://bunny.net/storage/): cheap edge storage with a simple HTTP API.
+- [Amazon S3 pre-signed URLs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-presigned-url.html): generate an upload URL from your own backend, then submit the resulting file URL to Formspark.

--- a/docs/setup/index.md
+++ b/docs/setup/index.md
@@ -44,4 +44,4 @@ You can rapidly test your form payloads by submitting to https://submit-form.com
 
 ## JavaScript
 
-Formspark has excellent AJAX support, [learn more about it here](/examples/ajax.html).
+Formspark has excellent AJAX support, [learn more about it here](/examples/ajax).

--- a/docs/setup/spam-protection.md
+++ b/docs/setup/spam-protection.md
@@ -5,7 +5,7 @@ lang: en-US
 
 # Spam protection
 
-Every form falls victim to spambots at some point, how you handle them can affect your customers.
+Every form falls victim to spambots at some point, and how you handle them can affect your customers.
 
 Formspark offers the following solutions to prevent spam:
 


### PR DESCRIPTION
Cleanup pass over the docs, prompted by the monorepo changes in PRs #128-#140.

## API corrections

- **Form settings restrictions were undocumented.** `POST`/`PATCH /forms` silently rejects most of what you might send. Now documented: the `spamProtection` enum (`BOTPOISON`, `GOOGLE_RECAPTCHA_V2`, `HCAPTCHA`, `TURNSTILE`), the requirement that the provider's secret key already be stored via the dashboard, the http/https rule on `webhookUrl`, and the cap of 10 notification emails.
- **`GET /workspaces` and `GET /forms` were not marked as paginated**, despite the pagination page claiming every list endpoint shares the envelope. Both now carry `limit` / `startingAfter`.
- **Cursors:** spelled out that they are opaque, must not be constructed or derived from `id`/`createdAt`, and that an unreadable or modified one is a `400 validation_error`.
- **The example problem details `type` URL was missing `.html`**, which is what `ProblemError` actually emits. All eight error anchors verified against the built HTML.

## Placeholder consistency

Every form id placeholder is now `your-form-id`, the string the backend serves a help page for. `FORM_ID` and `abc123` are gone. Custom routing keeps three distinct ids because the page routes to three different forms, now prefixed (`your-sales-form-id` and friends) so they still read as placeholders.

## Typos and prose

- The webhook payload example did not match its own form (`description` in the HTML, `message` in the JSON), and used an invalid self-closing `<textarea>`.
- Two file upload inputs were both labelled "Name".
- The Alpine.js states page claimed three states; the code tracks four.
- Plus: `recognise` → `recognize`, "view submission" → "view submissions", six em dashes, three comma splices, four stale `.html` links, and "paid workspaces" → "upgraded workspaces" to match how the product describes one-time upgrades.

## New examples

Analog, Remix and SolidStart, ported from the website snippets and rewritten in house style, with the server-side pattern leading where the framework has one. Sidebar entries included.

Prettier clean, build passes with dead-link checking on.