### PR TITLE
Fix three dead links

### DIFF
--- a/docs/api/errors.md
+++ b/docs/api/errors.md
@@ -78,4 +78,4 @@ The resource cannot be changed that way. Deleting a submission that was quaranti
 
 `500` · `internal_error`
 
-Something broke on our side. These are reported to us automatically. If one is reproducible, [let us know](https://formspark.io/support/contact).
+Something broke on our side. These are reported to us automatically. If one is reproducible, [let us know](https://dashboard.formspark.io/support/contact).

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -57,4 +57,4 @@ Retry a write only after checking whether it landed: a repeated `POST` creates a
 
 ## Rate limits
 
-Requests are limited per IP address. Sustained bursts from one address are blocked for a period. If you are planning something high-volume, [get in touch](https://formspark.io/support/contact) first.
+Requests are limited per IP address. Sustained bursts from one address are blocked for a period. If you are planning something high-volume, [get in touch](https://dashboard.formspark.io/support/contact) first.

--- a/docs/integration/make.md
+++ b/docs/integration/make.md
@@ -13,7 +13,7 @@ Connecting Formspark and Make takes only seconds.
 3. Inside the scenario editor, create a new module and select `Formspark`.
 4. Select the `New Submission` trigger.
 5. Select or create a webhook.
-6. Copy the webhook URL (example: https://hook.region.make.com/0123456789)
+6. Copy the webhook URL (example: `https://hook.region.make.com/0123456789`)
 7. Open Formspark
 8. Paste the webhook URL into the `Webhook URL` field found in your form's settings.
 9. Send a test submission to your form.

--- a/docs/troubleshooting/limits-and-plans.md
+++ b/docs/troubleshooting/limits-and-plans.md
@@ -9,19 +9,19 @@ Every Formspark account starts with one free workspace. Upgrading is a one-time 
 
 ## What each plan includes
 
-|                             | Free      | Upgraded                                                      |
-| --------------------------- | --------- | ------------------------------------------------------------- |
-| Submissions                 | 250       | 50,000 per bundle                                             |
-| Forms                       | 10        | 100                                                           |
-| Team members                | 5         | Unlimited                                                     |
-| Submission archive          | Forever   | Forever                                                       |
-| Spam protection             | Included  | Included                                                      |
-| Webhooks, Slack and Zapier  | Included  | Included                                                      |
-| Exports                     | Included  | Included                                                      |
-| Autoresponder               | No        | [Included](/dashboard/autoresponder)                          |
-| Removing Formspark branding | No        | [Included](/customization/feedback-page#_feedback-whitelabel) |
-| REST API                    | No        | [Included](/api/)                                             |
-| Support                     | Community | Customer assistance team                                      |
+|                             | Free      | Upgraded                                                     |
+| --------------------------- | --------- | ------------------------------------------------------------ |
+| Submissions                 | 250       | 50,000 per bundle                                            |
+| Forms                       | 10        | 100                                                          |
+| Team members                | 5         | Unlimited                                                    |
+| Submission archive          | Forever   | Forever                                                      |
+| Spam protection             | Included  | Included                                                     |
+| Webhooks, Slack and Zapier  | Included  | Included                                                     |
+| Exports                     | Included  | Included                                                     |
+| Autoresponder               | No        | [Included](/dashboard/autoresponder)                         |
+| Removing Formspark branding | No        | [Included](/customization/feedback-page#feedback-whitelabel) |
+| REST API                    | No        | [Included](/api/)                                            |
+| Support                     | Community | Customer assistance team                                     |
 
 ## How submissions are counted
 


### PR DESCRIPTION
Found by checking all 123 links on the live site (64 internal, 59 external) against the built output. All three predate the recent docs work.

- **`limits-and-plans.md`** — the plan table linked `/customization/feedback-page#_feedback-whitelabel`. VitePress drops the leading underscore when slugifying `### \`_feedback.whitelabel\``, so the real anchor is `#feedback-whitelabel`. The link landed on the page but not the section.
- **`api/errors.md`, `api/index.md`** — "let us know" and "get in touch" pointed at `https://formspark.io/support/contact`, a hard 404. The contact form lives at `https://dashboard.formspark.io/support/contact`, which is what formspark.io itself links to.
- **`integration/make.md`** — the illustrative webhook URL was written bare, so VitePress autolinked it into a clickable link to a host that does not resolve. Now backticked.

Verified after the change: 64 unique internal links, 0 broken, and the Make example is no longer an anchor.