### PR TITLE
Fix the deep-link 404s, and correct the last two weeks of docs

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -1,57 +1,49 @@
+import { sidebar } from "./sidebar.js";
+
+const SITE_URL = "https://documentation.formspark.io";
+const TITLE = "Formspark Documentation";
+const CDN = "https://cdn.formspark.io/images/formspark/logos";
+
+const meta = (entries) =>
+  Object.entries(entries).map(([key, content]) => [
+    "meta",
+    // og:* is an Open Graph property, everything else is a plain meta name.
+    { [key.startsWith("og:") ? "property" : "name"]: key, content },
+  ]);
+
 export default {
   lang: "en-US",
-  title: "Formspark Documentation",
+  title: TITLE,
   description: "Formspark documentation",
-  cleanUrls: true,
+  // The bucket serves the built files by exact key and rewrites nothing, so
+  // only .html paths and directory indexes resolve. Keep this false unless the
+  // hosting gains an extensionless rewrite: with it on, every deep link and
+  // sitemap entry misses, and the CloudFront error page answers with the home
+  // page under the requested page's title instead of a visible failure.
+  cleanUrls: false,
   sitemap: {
-    hostname: "https://documentation.formspark.io",
+    hostname: SITE_URL,
   },
   head: [
-    [
-      "link",
-      {
-        rel: "icon",
-        href: "https://cdn.formspark.io/images/formspark/logos/formspark.ico",
-      },
-    ],
-    [
-      "meta",
-      {
-        property: "og:title",
-        content: "Formspark Documentation",
-      },
-    ],
-    [
-      "meta",
-      {
-        property: "og:url",
-        content: "https://documentation.formspark.io",
-      },
-    ],
-    [
-      "meta",
-      {
-        property: "og:image",
-        content:
-          "https://cdn.formspark.io/images/formspark/logos/formspark--1200x630.png",
-      },
-    ],
-    ["meta", { property: "og:image:type", content: "image/png" }],
-    ["meta", { property: "og:image:width", content: "1200" }],
-    ["meta", { property: "og:image:height", content: "630" }],
-    ["meta", { name: "theme-color", content: "#707ee7" }],
-    ["meta", { name: "mobile-web-app-capable", content: "yes" }],
-    ["meta", { name: "apple-mobile-web-app-capable", content: "yes" }],
-    [
-      "meta",
-      { name: "apple-mobile-web-app-status-bar-style", content: "black" },
-    ],
+    ["link", { rel: "icon", href: `${CDN}/formspark.ico` }],
+    ...meta({
+      "og:title": TITLE,
+      "og:url": SITE_URL,
+      "og:image": `${CDN}/formspark--1200x630.png`,
+      "og:image:type": "image/png",
+      "og:image:width": "1200",
+      "og:image:height": "630",
+      "theme-color": "#707ee7",
+      "mobile-web-app-capable": "yes",
+      "apple-mobile-web-app-capable": "yes",
+      "apple-mobile-web-app-status-bar-style": "black",
+    }),
   ],
   themeConfig: {
-    logo: "https://cdn.formspark.io/images/formspark/logos/formspark.svg",
+    logo: `${CDN}/formspark.svg`,
     outline: [2, 3],
-    // The stock copy is a paraphrased Lao Tzu quote that says nothing about
-    // what went wrong or what to do next.
+    // Overrides the theme's stock copy, which offers a proverb rather than the
+    // two things a visitor here needs: why the page is missing, and where to go.
     notFound: {
       title: "Page not found",
       quote:
@@ -73,149 +65,6 @@ export default {
     search: {
       provider: "local",
     },
-    sidebar: [
-      {
-        text: "Introduction",
-        items: [{ text: "About", link: "/" }],
-      },
-      {
-        text: "Setup",
-        items: [
-          { text: "Installation", link: "/setup/" },
-          { text: "Spam protection", link: "/setup/spam-protection" },
-          { text: "File uploads", link: "/setup/file-uploads" },
-          { text: "Arrays and objects", link: "/setup/arrays-and-objects" },
-        ],
-      },
-      {
-        text: "Customization",
-        items: [
-          { text: "Redirection", link: "/customization/redirection" },
-          { text: "Feedback page", link: "/customization/feedback-page" },
-          {
-            text: "Notification email",
-            link: "/customization/notification-email",
-          },
-          { text: "Direct replies", link: "/customization/direct-replies" },
-          { text: "Custom routing", link: "/customization/custom-routing" },
-        ],
-      },
-      {
-        text: "Dashboard",
-        items: [
-          {
-            text: "Inviting team members",
-            link: "/dashboard/inviting-team-members",
-          },
-          {
-            text: "Additional workspaces",
-            link: "/dashboard/additional-workspaces",
-          },
-          {
-            text: "Redeeming vouchers",
-            link: "/dashboard/redeeming-vouchers",
-          },
-          {
-            text: "Email notification settings",
-            link: "/dashboard/email-notification-settings",
-          },
-          {
-            text: "Autoresponder",
-            link: "/dashboard/autoresponder",
-          },
-          {
-            text: "Exporting submissions",
-            link: "/dashboard/exporting-submissions",
-          },
-        ],
-      },
-      {
-        text: "HTML form",
-        items: [
-          { text: "Form validation", link: "/html-form/form-validation" },
-          { text: "Form styling", link: "/html-form/form-styling" },
-          {
-            text: "Special input types",
-            link: "/html-form/special-input-types",
-          },
-          { text: "Drop-down list", link: "/html-form/drop-down-list" },
-          {
-            text: "Submit in different tab",
-            link: "/html-form/submit-in-different-tab",
-          },
-        ],
-      },
-      {
-        text: "Examples",
-        items: [
-          { text: "AJAX submissions", link: "/examples/ajax" },
-          { text: "Alpine.js", link: "/examples/alpinejs" },
-          { text: "Analog", link: "/examples/analog" },
-          { text: "Angular", link: "/examples/angular" },
-          { text: "Astro", link: "/examples/astro" },
-          { text: "Eleventy", link: "/examples/eleventy" },
-          { text: "Framer", link: "/examples/framer" },
-          { text: "Gatsby", link: "/examples/gatsby" },
-          { text: "HTMX", link: "/examples/htmx" },
-          { text: "Hugo", link: "/examples/hugo" },
-          { text: "Jekyll", link: "/examples/jekyll" },
-          { text: "Next.js", link: "/examples/nextjs" },
-          { text: "Nuxt", link: "/examples/nuxtjs" },
-          { text: "Preact", link: "/examples/preact" },
-          { text: "Qwik", link: "/examples/qwik" },
-          { text: "React", link: "/examples/react" },
-          { text: "React Native", link: "/examples/react-native" },
-          { text: "Remix", link: "/examples/remix" },
-          { text: "SolidStart", link: "/examples/solidstart" },
-          { text: "Svelte", link: "/examples/svelte" },
-          { text: "SvelteKit", link: "/examples/sveltekit" },
-          { text: "VitePress", link: "/examples/vitepress" },
-          { text: "Vue", link: "/examples/vue" },
-          { text: "Webflow", link: "/examples/webflow" },
-          { text: "WordPress", link: "/examples/wordpress" },
-        ],
-      },
-      {
-        text: "Integrations",
-        items: [
-          { text: "Overview", link: "/integration/" },
-          { text: "Airtable", link: "/integration/airtable" },
-          { text: "Google Sheets", link: "/integration/google-sheets" },
-          { text: "Make", link: "/integration/make" },
-          { text: "Notion", link: "/integration/notion" },
-          { text: "Slack", link: "/integration/slack" },
-          { text: "UTM parameters", link: "/integration/utm-parameters" },
-          { text: "Webhooks", link: "/integration/webhooks" },
-          { text: "Zapier", link: "/integration/zapier" },
-        ],
-      },
-      {
-        text: "API",
-        items: [
-          { text: "Overview", link: "/api/" },
-          { text: "API tokens", link: "/api/api-tokens" },
-          { text: "Reference", link: "/api/reference" },
-          { text: "Pagination", link: "/api/pagination" },
-          { text: "Errors", link: "/api/errors" },
-        ],
-      },
-      {
-        text: "Troubleshooting",
-        items: [
-          {
-            text: "Common issues",
-            link: "/troubleshooting/common-issues",
-          },
-          {
-            text: "Limits and plans",
-            link: "/troubleshooting/limits-and-plans",
-          },
-          {
-            text: "Email reception",
-            link: "/troubleshooting/email-reception",
-          },
-        ],
-      },
-    ],
+    sidebar,
   },
 };

--- a/docs/.vitepress/sidebar.js
+++ b/docs/.vitepress/sidebar.js
@@ -1,0 +1,146 @@
+// The documentation's navigation tree. Every page belongs to exactly one
+// group, and a group's order is the order a reader is expected to need it.
+export const sidebar = [
+  {
+    text: "Introduction",
+    items: [{ text: "About", link: "/" }],
+  },
+  {
+    text: "Setup",
+    items: [
+      { text: "Installation", link: "/setup/" },
+      { text: "Spam protection", link: "/setup/spam-protection" },
+      { text: "File uploads", link: "/setup/file-uploads" },
+      { text: "Arrays and objects", link: "/setup/arrays-and-objects" },
+    ],
+  },
+  {
+    text: "Customization",
+    items: [
+      { text: "Redirection", link: "/customization/redirection" },
+      { text: "Feedback page", link: "/customization/feedback-page" },
+      {
+        text: "Notification email",
+        link: "/customization/notification-email",
+      },
+      { text: "Direct replies", link: "/customization/direct-replies" },
+      { text: "Custom routing", link: "/customization/custom-routing" },
+    ],
+  },
+  {
+    text: "Dashboard",
+    items: [
+      {
+        text: "Inviting team members",
+        link: "/dashboard/inviting-team-members",
+      },
+      {
+        text: "Additional workspaces",
+        link: "/dashboard/additional-workspaces",
+      },
+      {
+        text: "Redeeming vouchers",
+        link: "/dashboard/redeeming-vouchers",
+      },
+      {
+        text: "Email notification settings",
+        link: "/dashboard/email-notification-settings",
+      },
+      {
+        text: "Autoresponder",
+        link: "/dashboard/autoresponder",
+      },
+      {
+        text: "Exporting submissions",
+        link: "/dashboard/exporting-submissions",
+      },
+    ],
+  },
+  {
+    text: "HTML form",
+    items: [
+      { text: "Form validation", link: "/html-form/form-validation" },
+      { text: "Form styling", link: "/html-form/form-styling" },
+      {
+        text: "Special input types",
+        link: "/html-form/special-input-types",
+      },
+      { text: "Drop-down list", link: "/html-form/drop-down-list" },
+      {
+        text: "Submit in different tab",
+        link: "/html-form/submit-in-different-tab",
+      },
+    ],
+  },
+  {
+    text: "Examples",
+    items: [
+      { text: "AJAX submissions", link: "/examples/ajax" },
+      { text: "Alpine.js", link: "/examples/alpinejs" },
+      { text: "Analog", link: "/examples/analog" },
+      { text: "Angular", link: "/examples/angular" },
+      { text: "Astro", link: "/examples/astro" },
+      { text: "Eleventy", link: "/examples/eleventy" },
+      { text: "Framer", link: "/examples/framer" },
+      { text: "Gatsby", link: "/examples/gatsby" },
+      { text: "HTMX", link: "/examples/htmx" },
+      { text: "Hugo", link: "/examples/hugo" },
+      { text: "Jekyll", link: "/examples/jekyll" },
+      { text: "Next.js", link: "/examples/nextjs" },
+      { text: "Nuxt", link: "/examples/nuxtjs" },
+      { text: "Preact", link: "/examples/preact" },
+      { text: "Qwik", link: "/examples/qwik" },
+      { text: "React", link: "/examples/react" },
+      { text: "React Native", link: "/examples/react-native" },
+      { text: "Remix", link: "/examples/remix" },
+      { text: "SolidStart", link: "/examples/solidstart" },
+      { text: "Svelte", link: "/examples/svelte" },
+      { text: "SvelteKit", link: "/examples/sveltekit" },
+      { text: "VitePress", link: "/examples/vitepress" },
+      { text: "Vue", link: "/examples/vue" },
+      { text: "Webflow", link: "/examples/webflow" },
+      { text: "WordPress", link: "/examples/wordpress" },
+    ],
+  },
+  {
+    text: "Integrations",
+    items: [
+      { text: "Overview", link: "/integration/" },
+      { text: "Airtable", link: "/integration/airtable" },
+      { text: "Google Sheets", link: "/integration/google-sheets" },
+      { text: "Make", link: "/integration/make" },
+      { text: "Notion", link: "/integration/notion" },
+      { text: "Slack", link: "/integration/slack" },
+      { text: "UTM parameters", link: "/integration/utm-parameters" },
+      { text: "Webhooks", link: "/integration/webhooks" },
+      { text: "Zapier", link: "/integration/zapier" },
+    ],
+  },
+  {
+    text: "API",
+    items: [
+      { text: "Overview", link: "/api/" },
+      { text: "API tokens", link: "/api/api-tokens" },
+      { text: "Reference", link: "/api/reference" },
+      { text: "Pagination", link: "/api/pagination" },
+      { text: "Errors", link: "/api/errors" },
+    ],
+  },
+  {
+    text: "Troubleshooting",
+    items: [
+      {
+        text: "Common issues",
+        link: "/troubleshooting/common-issues",
+      },
+      {
+        text: "Limits and plans",
+        link: "/troubleshooting/limits-and-plans",
+      },
+      {
+        text: "Email reception",
+        link: "/troubleshooting/email-reception",
+      },
+    ],
+  },
+];

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -14,13 +14,14 @@
   }
 }
 
-/* A not-found page keeps the has-sidebar class of whatever path was asked for,
-   so the layout reserves --vp-sidebar-width, but renders no sidebar to fill it
-   and the message ends up that far right of centre. Reclaim the reservation
-   wherever the not-found view is what is being shown.
+/* The not-found view inherits the has-sidebar class from the requested path but
+   renders no sidebar, so the space that class reserves has to be reclaimed for
+   the content to sit centred. Zero the inline padding as a pair: has-sidebar
+   sets a left inset for the sidebar and a right one for the outline, and
+   clearing only one leaves the content off centre by half the other.
 
-   Both class names are needed: the rule this overrides is .VPContent.has-sidebar,
-   which carries the same specificity, and it is bundled after this file. */
+   Keep both class names: this overrides .VPContent.has-sidebar, which has equal
+   specificity and is bundled after this file, so a shorter selector loses. */
 .VPContent.has-sidebar:has(.NotFound) {
-  padding-left: 0;
+  padding-inline: 0;
 }

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -95,9 +95,23 @@ Deletes the form and its submissions. Scope: `forms:write`.
 
 `POST /forms` and `PATCH /forms/{formId}` accept a form's settings, with a few restrictions. Anything the API rejects comes back as a [`validation_error`](./errors#validation-error).
 
+Beyond the three settings described below, a form carries these fields. Each of them accepts `null` to clear it, except `name`, which a form always has.
+
+| Field             | Type                    |
+| ----------------- | ----------------------- |
+| `name`            | string, 128 characters  |
+| `description`     | string, 512 characters  |
+| `technology`      | string, 128 characters  |
+| `slackChannel`    | string, 128 characters  |
+| `customHoneypot`  | string, 128 characters  |
+| `customSpamWords` | string, 2560 characters |
+| `emailThreading`  | boolean                 |
+
+`customHoneypot` and `customSpamWords` are the API side of the settings described under [spam protection](/setup/spam-protection#custom-spam-words).
+
 #### `spamProtection`
 
-Accepts one of four values:
+Accepts one of four providers, or `null` to require no challenge at all:
 
 | Value                 | Provider     |
 | --------------------- | ------------ |
@@ -112,11 +126,11 @@ The provider's secret key is not part of the API. Store it in the dashboard firs
 
 #### `webhookUrl`
 
-Must be an `http` or `https` URL. See [webhooks](/integration/webhooks).
+Must be an `http` or `https` URL, and must resolve to a public address when Formspark calls it, so an endpoint on `localhost` or a private network is rejected. See [webhooks](/integration/webhooks).
 
 #### `notificationEmails`
 
-A form accepts at most 10 notification emails. Since the list you send replaces the existing one, read the current list back first if you are adding to it rather than replacing it.
+A form accepts at most 100 notification emails, each at most 128 characters. Since the list you send replaces the existing one, read the current list back first if you are adding to it rather than replacing it.
 
 ## Submissions
 
@@ -139,4 +153,4 @@ The same, across every form in the workspace. Scope: `submissions:read`.
 
 Scope: `submissions:write`.
 
-Submissions rejected as spam expire on their own and cannot be deleted early. Deleting one returns a [`conflict`](./errors#conflict).
+Submissions quarantined as spam expire on their own and cannot be deleted early. Deleting one returns a [`conflict`](./errors#conflict).

--- a/docs/customization/custom-routing.md
+++ b/docs/customization/custom-routing.md
@@ -31,20 +31,17 @@ Each option points at a form of its own, so create one form per destination and 
 </form>
 
 <script>
-  onChange = function (event) {
-    let action;
-    switch (event.value) {
-      case "sales":
-        action = "https://submit-form.com/your-sales-form-id";
-        break;
-      case "marketing":
-        action = "https://submit-form.com/your-marketing-form-id";
-        break;
-      case "hr":
-        action = "https://submit-form.com/your-hr-form-id";
-        break;
-    }
-    document.getElementById("my-form").action = action;
+  const FORM_IDS = {
+    sales: "your-sales-form-id",
+    marketing: "your-marketing-form-id",
+    hr: "your-hr-form-id",
   };
+
+  function onChange(select) {
+    const formId = FORM_IDS[select.value];
+    if (!formId) return;
+    document.getElementById("my-form").action =
+      "https://submit-form.com/" + formId;
+  }
 </script>
 ```

--- a/docs/customization/feedback-page.md
+++ b/docs/customization/feedback-page.md
@@ -19,7 +19,7 @@ You need an [upgraded workspace](/troubleshooting/limits-and-plans) to unlock th
 Default value: false
 
 ```html
-<form action="https://submit-form.com/your-form-id">
+<form action="https://submit-form.com/your-form-id" method="POST">
   <input type="hidden" name="_feedback.whitelabel" value="true" />
   <input type="email" name="email" />
   <button type="submit">Subscribe</button>
@@ -33,7 +33,7 @@ Toggles dark mode.
 Default value: false
 
 ```html
-<form action="https://submit-form.com/your-form-id">
+<form action="https://submit-form.com/your-form-id" method="POST">
   <input type="hidden" name="_feedback.dark" value="true" />
   <input type="email" name="email" />
   <button type="submit">Subscribe</button>
@@ -90,7 +90,7 @@ Default value: "Please try again."
 ### Example
 
 ```html
-<form action="https://submit-form.com/your-form-id">
+<form action="https://submit-form.com/your-form-id" method="POST">
   <input
     type="hidden"
     name="_feedback.success.title"

--- a/docs/customization/redirection.md
+++ b/docs/customization/redirection.md
@@ -16,7 +16,7 @@ This default behavior can be overridden in multiple ways.
 3. Set the value to the URL you want to redirect users to.
 
 ```html
-<form action="https://submit-form.com/your-form-id">
+<form action="https://submit-form.com/your-form-id" method="POST">
   <input
     type="hidden"
     name="_redirect"
@@ -48,7 +48,7 @@ automatically be inherited.
 3. Set the value to the URL you want to redirect users to.
 
 ```html
-<form action="https://submit-form.com/your-form-id">
+<form action="https://submit-form.com/your-form-id" method="POST">
   <input type="hidden" name="_error" value="https://your-website.com/error" />
   <input type="email" name="email" />
   <button type="submit">Subscribe</button>
@@ -73,7 +73,7 @@ Formspark has excellent AJAX support, [learn more about it here](/examples/ajax)
 <!--
 1. If your form is hosted at "https://my-website.com/newsletter.html"
 -->
-<form action="https://submit-form.com/your-form-id">
+<form action="https://submit-form.com/your-form-id" method="POST">
   <!-- 2. Then you would set the "_redirect" to "https://my-website.com/newsletter.html" -->
   <input
     type="hidden"

--- a/docs/examples/angular.md
+++ b/docs/examples/angular.md
@@ -29,6 +29,7 @@ flight and show your own confirmation.
 import { Component, inject } from "@angular/core";
 import { HttpClient } from "@angular/common/http";
 import { FormBuilder, ReactiveFormsModule } from "@angular/forms";
+import { finalize } from "rxjs";
 
 const FORMSPARK_ACTION_URL = "https://submit-form.com/your-form-id";
 
@@ -54,18 +55,26 @@ export class ContactFormComponent {
 
   onSubmit() {
     this.form.disable();
-    this.http.post(FORMSPARK_ACTION_URL, this.form.value).subscribe({
-      complete: () => {
-        this.form.enable();
-        this.form.reset();
-      },
-    });
+    this.http
+      .post(FORMSPARK_ACTION_URL, this.form.value, {
+        headers: { Accept: "application/json" },
+      })
+      .pipe(finalize(() => this.form.enable()))
+      .subscribe({
+        next: () => this.form.reset(),
+      });
   }
 }
 ```
 
-`HttpClient` sets `Content-Type: application/json` for an object body and
-Formspark replies with JSON, so nothing else needs configuring.
+`HttpClient` sets `Content-Type: application/json` for an object body, but it
+sends no `Accept` header of its own. Ask for `application/json` explicitly:
+without it Formspark answers a submission with a redirect to the feedback page
+rather than JSON, which `HttpClient` then fails to parse.
+
+`finalize` re-enables the form whether the request succeeds or fails. A plain
+`complete` callback never runs on error, which would leave the form disabled for
+good.
 
 Remember to provide `HttpClient` in your application bootstrap:
 

--- a/docs/examples/qwik.md
+++ b/docs/examples/qwik.md
@@ -8,7 +8,7 @@ lang: en-US
 ## routeAction$
 
 `routeAction$` runs on the server, so the submission works before the page has
-hydrated and your form id is never exposed to the browser.
+hydrated and keeps working with JavaScript disabled.
 
 ```tsx
 import { component$ } from "@builder.io/qwik";
@@ -51,7 +51,10 @@ export default component$(() => {
 
 ## Fetch
 
-If you would rather submit from the browser, use a `$` handler and a signal.
+If you would rather submit from the browser, use a `$` handler and a signal. The
+action URL ends up in the client bundle here, which is no different from a plain
+HTML form: a form id identifies a form, it does not authorize anything, so it is
+safe to ship to the browser.
 
 ```tsx
 import { component$, useSignal, $ } from "@builder.io/qwik";

--- a/docs/examples/vitepress.md
+++ b/docs/examples/vitepress.md
@@ -5,9 +5,14 @@ lang: en-US
 
 # VitePress
 
-VitePress renders pages on the server at build time, so a form that submits
-with `fetch` has to be wrapped in `<ClientOnly>` to avoid a hydration
-mismatch.
+VitePress renders pages at build time and hydrates them in the browser. A form
+whose markup does not depend on anything browser-specific renders the same in
+both passes, so it needs no special handling — the `fetch` only runs once the
+visitor submits.
+
+Reach for `<ClientOnly>` only when a component reads something that exists in
+the browser alone, such as `window`, `localStorage` or the current URL, while it
+is setting up or rendering.
 
 ## Theme component
 
@@ -41,15 +46,13 @@ const onSubmit = async () => {
 </script>
 
 <template>
-  <ClientOnly>
-    <form @submit.prevent="onSubmit">
-      <label>
-        <span>Message</span>
-        <textarea v-model="message"></textarea>
-      </label>
-      <button type="submit" :disabled="submitting">Send</button>
-    </form>
-  </ClientOnly>
+  <form @submit.prevent="onSubmit">
+    <label>
+      <span>Message</span>
+      <textarea v-model="message"></textarea>
+    </label>
+    <button type="submit" :disabled="submitting">Send</button>
+  </form>
 </template>
 ```
 

--- a/docs/html-form/drop-down-list.md
+++ b/docs/html-form/drop-down-list.md
@@ -13,7 +13,7 @@ Use the `multiple` attribute to specify whether multiple options can be selected
 
 ```html
 <!-- Single option (selection persisted as a string) -->
-<form action="https://submit-form.com/your-form-id">
+<form action="https://submit-form.com/your-form-id" method="POST">
   <select name="car">
     <option value="volvo">Volvo</option>
     <option value="saab">Saab</option>
@@ -26,7 +26,7 @@ Use the `multiple` attribute to specify whether multiple options can be selected
 
 ```html
 <!-- Multiple options (selection persisted as an array)-->
-<form action="https://submit-form.com/your-form-id">
+<form action="https://submit-form.com/your-form-id" method="POST">
   <select name="vegetables" multiple>
     <option value="tomato">Tomato</option>
     <option value="carrot">Carrot</option>
@@ -64,7 +64,7 @@ Use `<optgroup>` to organize related options under a heading.
 A `<datalist>` provides suggestions for a plain text input. Unlike `<select>`, the user can still type any value.
 
 ```html
-<form action="https://submit-form.com/your-form-id">
+<form action="https://submit-form.com/your-form-id" method="POST">
   <label for="country">Country</label>
   <input list="countries" id="country" name="country" />
   <datalist id="countries">

--- a/docs/html-form/form-styling.md
+++ b/docs/html-form/form-styling.md
@@ -27,7 +27,11 @@ On this page you'll find tips, tricks and links to help you style your forms.
     </style>
   </head>
   <body>
-    <form class="vertical-form" action="https://submit-form.com/your-form-id">
+    <form
+      class="vertical-form"
+      action="https://submit-form.com/your-form-id"
+      method="POST"
+    >
       <label for="first-name">First name</label>
       <input id="first-name" name="first-name" type="text" />
       <label for="last-name">Last name</label>
@@ -67,7 +71,11 @@ Pair every input with a `<label for>`, give focused fields a visible outline, an
   }
 </style>
 
-<form class="accessible-form" action="https://submit-form.com/your-form-id">
+<form
+  class="accessible-form"
+  action="https://submit-form.com/your-form-id"
+  method="POST"
+>
   <label for="email">Email</label>
   <input id="email" name="email" type="email" required />
 
@@ -84,6 +92,7 @@ Pair every input with a `<label for>`, give focused fields a visible outline, an
 <form
   class="mx-auto flex max-w-md flex-col gap-3"
   action="https://submit-form.com/your-form-id"
+  method="POST"
 >
   <label for="email" class="font-semibold">Email</label>
   <input
@@ -128,7 +137,7 @@ Pair every input with a `<label for>`, give focused fields a visible outline, an
     </style>
   </head>
   <body>
-    <form action="https://submit-form.com/your-form-id">
+    <form action="https://submit-form.com/your-form-id" method="POST">
       <label for="first-name" class="required">First name</label>
       <input id="first-name" name="first-name" type="text" required />
       <label for="last-name">Last name</label>
@@ -144,7 +153,7 @@ Pair every input with a `<label for>`, give focused fields a visible outline, an
 When you submit via AJAX, you control the post-submission UI yourself. A common pattern is to swap the form for a thank-you message on success and show an inline error on failure.
 
 ```html
-<form id="contact" action="https://submit-form.com/your-form-id">
+<form id="contact" action="https://submit-form.com/your-form-id" method="POST">
   <label for="message">Message</label>
   <textarea id="message" name="message" required></textarea>
   <button type="submit">Send</button>

--- a/docs/html-form/form-validation.md
+++ b/docs/html-form/form-validation.md
@@ -22,7 +22,7 @@ Formspark performs no server-side validation. Validate your inputs client-side b
 The `required` attribute is a boolean attribute. When present, it specifies that an input field must be filled out before submitting the form.
 
 ```html
-<form action="https://submit-form.com/your-form-id">
+<form action="https://submit-form.com/your-form-id" method="POST">
   <input type="email" name="email" required />
   <textarea name="message" required></textarea>
   <button type="submit">Send</button>
@@ -60,7 +60,7 @@ The `title` attribute is shown by the browser when the pattern fails.
 Use `setCustomValidity` to replace the default browser message.
 
 ```html
-<form action="https://submit-form.com/your-form-id">
+<form action="https://submit-form.com/your-form-id" method="POST">
   <input type="email" name="email" id="email" required />
   <button type="submit">Send</button>
 </form>

--- a/docs/integration/index.md
+++ b/docs/integration/index.md
@@ -15,13 +15,12 @@ Connect them from the **Integrations** section of your form's settings in the
 
 ## Collect submissions in a document
 
-Formspark creates the document for you and keeps appending to it. Rows sync on
-a schedule, so a submission appears shortly after it arrives rather than
-instantly.
+Formspark creates the document for you and keeps appending to it.
 
 - [Google Sheets](./google-sheets) — a spreadsheet, one row per submission
 - [Notion](./notion) — a database, one page per submission
-- [Airtable](./airtable) — a base, through Make
+
+Both need an [upgraded workspace](/troubleshooting/limits-and-plans).
 
 ## Get notified in chat
 
@@ -32,6 +31,13 @@ instantly.
 - [Webhooks](./webhooks) — an HTTP request to a URL of your choice
 - [Zapier](./zapier) — thousands of apps, no code needed
 - [Make](./make) — visual scenarios, no code needed
+
+## Reach a tool Formspark does not connect to directly
+
+Zapier and Make bridge submissions to anything they support, so a tool without
+its own Formspark integration is usually still reachable.
+
+- [Airtable](./airtable) — a base, through Zapier or Make
 
 ## Enrich what you collect
 

--- a/docs/integration/make.md
+++ b/docs/integration/make.md
@@ -13,8 +13,8 @@ Connecting Formspark and Make takes only seconds.
 3. Inside the scenario editor, create a new module and select `Formspark`.
 4. Select the `New Submission` trigger.
 5. Select or create a webhook.
-6. Copy the webhook URL (example: `https://hook.region.make.com/0123456789`)
-7. Open Formspark
+6. Copy the webhook URL (example: `https://hook.region.make.com/0123456789`).
+7. Open Formspark.
 8. Paste the webhook URL into the `Webhook URL` field found in your form's settings.
 9. Send a test submission to your form.
 

--- a/docs/integration/utm-parameters.md
+++ b/docs/integration/utm-parameters.md
@@ -21,7 +21,11 @@ Add the Formtrack script.
 Add a `data-formtrack` attribute to your form element.
 
 ```html
-<form action="https://submit-form.com/your-form-id" data-formtrack>
+<form
+  action="https://submit-form.com/your-form-id"
+  method="POST"
+  data-formtrack
+>
   <input type="text" name="message" />
   <button type="submit">Send</button>
 </form>
@@ -50,6 +54,7 @@ Include a `data-formtrack-params` attribute within your form element, and popula
 ```html
 <form
   action="https://submit-form.com/your-form-id"
+  method="POST"
   data-formtrack
   data-formtrack-params="custom_param_1,custom_param_2"
 >

--- a/docs/integration/webhooks.md
+++ b/docs/integration/webhooks.md
@@ -19,7 +19,7 @@ Formspark can send webhook events that notify your application any time you rece
 Given the following form:
 
 ```html
-<form action="https://submit-form.com/your-form-id">
+<form action="https://submit-form.com/your-form-id" method="POST">
   <input type="text" name="email" />
   <textarea name="message"></textarea>
   <button type="submit">Send</button>

--- a/docs/setup/file-uploads.md
+++ b/docs/setup/file-uploads.md
@@ -24,7 +24,7 @@ free plan.
 Start with a simple Formspark form.
 
 ```html
-<form action="https://submit-form.com/your-form-id">
+<form action="https://submit-form.com/your-form-id" method="POST">
   <!-- Name -->
   <label for="name">Name</label>
   <input type="text" id="name" name="name" placeholder="Name" required="" />
@@ -74,7 +74,7 @@ Final code:
     <script src="https://ucarecdn.com/libs/widget/3.x/uploadcare.full.min.js"></script>
   </head>
   <body>
-    <form action="https://submit-form.com/your-form-id">
+    <form action="https://submit-form.com/your-form-id" method="POST">
       <!-- Name -->
       <label for="name">Name</label>
       <input type="text" id="name" name="name" placeholder="Name" required="" />

--- a/docs/setup/index.md
+++ b/docs/setup/index.md
@@ -12,7 +12,7 @@ Every form in Formspark has its own action URL. To get one, sign in to the [Form
 ## HTML
 
 ```html
-<form action="https://submit-form.com/your-form-id">
+<form action="https://submit-form.com/your-form-id" method="POST">
   <input type="email" name="email" />
   <button type="submit">Subscribe</button>
 </form>
@@ -34,7 +34,7 @@ Input names starting with an underscore are reserved and will be hidden from the
 You can rapidly test your form payloads by submitting to https://submit-form.com/echo.
 
 ```html
-<form action="https://submit-form.com/echo">
+<form action="https://submit-form.com/echo" method="POST">
   <input type="text" name="message" />
   <button type="submit">Send</button>
 </form>

--- a/docs/setup/spam-protection.md
+++ b/docs/setup/spam-protection.md
@@ -115,7 +115,7 @@ Formspark integrates with Google's reCAPTCHA v2 "I'm not a robot" checkbox.
 
 Your form is now protected by reCAPTCHA ✔.
 
-To stop using reCAPTCHA, change your `Captcha provider` to `None`.
+To stop using reCAPTCHA, change your `Spam Protection` to `None`.
 
 ### HTML
 
@@ -172,7 +172,7 @@ Make sure your form's `method` attribute is explicitly set to `POST`.
 
 ### AJAX
 
-If you're using AJAX, add the hCAPTCHA response to your submission body via the `h-captcha-response` property.
+If you're using AJAX, add the hCaptcha response to your submission body via the `h-captcha-response` property.
 
 ```javascript
 const body = {
@@ -233,7 +233,7 @@ We scan all values in your form's submission body for the words you specify. If 
 
 You specify the comma-separated list of words in your form's settings, under `Custom spam words`.
 
-The total length of the list must not exceed 2,500 characters.
+The total length of the list must not exceed 2,560 characters.
 
 ## Honeypot
 
@@ -246,7 +246,7 @@ The honeypot technique is a simple-to-implement spam prevention solution.
 To enable this feature, add a field with the name `_honeypot` or `_gotcha` to your form and hide it with CSS (see example below). The submission will be silently ignored when a spam bot enters a value.
 
 ```html
-<form action="https://submit-form.com/your-form-id">
+<form action="https://submit-form.com/your-form-id" method="POST">
   <input
     type="checkbox"
     name="_honeypot"
@@ -264,7 +264,7 @@ To enable this feature, add a field with the name `_honeypot` or `_gotcha` to yo
 Instead of using `_honeypot` or `_gotcha`, you can specify your own honeypot name in your form's settings.
 
 ```html
-<form action="https://submit-form.com/your-form-id">
+<form action="https://submit-form.com/your-form-id" method="POST">
   <input
     type="checkbox"
     name="Paste your custom honeypot here"

--- a/docs/troubleshooting/common-issues.md
+++ b/docs/troubleshooting/common-issues.md
@@ -17,8 +17,8 @@ lang: en-US
 ## I cannot find my forms
 
 1. Ensure that you are signed in with the correct email address.
-2. Ensure that you are connected to the right workspace: [View My Workspaces](https://dashboard.formspark.io/workspaces)
-   .
+2. Ensure that you are connected to the right workspace:
+   [View My Workspaces](https://dashboard.formspark.io/workspaces).
 
 ## I cannot find my workspace
 


### PR DESCRIPTION
Reviewing everything changed in the last two weeks turned up a production
bug in front of the content work, so that comes first.

## Every deep link was serving the wrong page

`cleanUrls: true` had VitePress write extensionless internal links and
sitemap entries, but the bucket resolves only exact keys and directory
indexes. So `https://documentation.formspark.io/api/reference` answered
**404**, CloudFront's error page returned `index.html`, and the SPA
booted at the requested path — leaving the **home page rendered under
the requested page's title**:

| URL | Before | After |
| --- | --- | --- |
| `/api/reference` | 404, renders *About* | n/a — no longer emitted |
| `/api/reference.html` | 200, correct | 200, correct, and what the site links to |

All 64 sitemap URLs were in that state, so crawlers saw nothing but the
section indexes. In-app navigation hid it, which is why it went unnoticed.

Setting `cleanUrls: false` emits the `.html` paths the host already
serves — and that matches what the API itself hands out in its error
payloads (`.../api/errors.html#invalid-token`). The alternative is an
extensionless rewrite at CloudFront, which is outside this repo; the
config carries a comment saying not to flip the flag back without it.

Verified: **0 broken internal hrefs** across all 65 built pages, and all
63 sidebar pages render with no JS errors.

## Corrections found against the live API

Checked `api/reference.md` against `api.formspark.io/public/v1/openapi.json`:

- `notificationEmails` caps at **100**, the page said 10.
- `spamProtection` accepts **`null`** to require no challenge — a fifth
  value, on a page that said no other value is accepted.
- `webhookUrl` must resolve to a **public** address, so a `localhost`
  endpoint is rejected. That wasn't mentioned.
- Custom spam words allow **2560** characters, not 2500.
- Added the settable fields the reference omitted entirely.

## Wrong claims in the new framework examples

- **Angular** — `HttpClient` sends no `Accept` header, so the submission
  came back as a redirect to the feedback page rather than the JSON the
  prose promised, which `responseType: json` then fails to parse. Also
  `subscribe({ complete })` never fires on error, so any failure left
  the form permanently disabled; now `finalize`.
- **VitePress** — markup that reads nothing browser-specific hydrates
  identically, so `<ClientOnly>` wasn't required and the
  hydration-mismatch reasoning was wrong.
- **Qwik** — a form id identifies a form, it doesn't authorize anything,
  so framing server-side submission as keeping it secret misleads. The
  fetch example on the same page ships it to the browser anyway.

## Also

- The not-found page was still 40px off centre: `has-sidebar` insets
  content from *both* sides and only `padding-left` was being zeroed.
- The integrations overview filed Airtable under documents Formspark
  creates and appends to — it does neither, and the Airtable page
  recommends Zapier, not Make. Dropped an unsupported "syncs on a
  schedule" claim too.
- `method="POST"` on the form examples in the touched pages, matching the
  newer pages and the reCAPTCHA/hCaptcha sections that require it.
- Assorted copy: `Captcha provider` → `Spam Protection`, `hCAPTCHA` →
  `hCaptcha`, a stranded full stop, two missing full stops, and a custom
  routing handler that assigned to an implicit global.
- `config.js` is now configuration: the 145-line sidebar moved to
  `sidebar.js` and the repeated `head` entries fold into a helper. The
  rendered `<head>` is byte-identical.
- Reworked the two comments added recently to match the house rules in
  `AGENTS.md` (no bug war stories, describe the standing constraint).

## Not done, and why

You chose no new tooling, so the first, second, fourth and fifth items on
your list don't apply here: there is no test framework, no ESLint, and no
TypeScript in this repo. `eslint-disable`, `ts-ignore`, `ts-expect-error`
and `any` were already at zero — vacuously, there being nothing to lint
or type. `AGENTS.md` doesn't exist in this repo either; I followed the one
in `formspark/httphq`.

Two things I deliberately left alone:

- 12 form examples in pages **outside** the two-week window still default
  to GET (`wordpress`, `jekyll`, `hugo`, `arrays-and-objects`,
  `special-input-types`, `submit-in-different-tab`). Happy to sweep them
  in a follow-up.
- `limit`'s documented default of 25 isn't declared in the OpenAPI schema.
  I couldn't confirm it without a token, so I left the claim as-is.

## QA

Built and served the production output through a server that mimics the
bucket (exact keys, `index.html` on miss) and walked it in Chrome:

- All 63 sidebar pages: correct `h1`, no NotFound, no JS errors.
- Every changed page checked in the rendered build.
- `<head>` verified tag by tag against the old hand-written array.
- Local search returns results, and they navigate to the right anchor.
- Dark mode, 390px mobile (no horizontal overflow, code blocks scroll).
- Not-found page centred: block, heading and viewport centres all agree.