### PR TITLE
Separate bot duplicates from visitor duplicates

### DIFF
--- a/docs/troubleshooting/common-issues.md
+++ b/docs/troubleshooting/common-issues.md
@@ -48,12 +48,80 @@ fetch("https://submit-form.com/your-form-id", {
 
 Without those headers Formspark may treat the body as something other than JSON and silently discard it.
 
+## I'm receiving the same notification several times
+
+Formspark sends one notification per accepted submission. Several identical
+emails therefore means the form was submitted several times, not that one
+notification was sent again.
+
+Open the form in your dashboard and compare the timestamps. Duplicate
+submissions appear as separate entries, often only seconds apart. Once you know
+how many arrived, see
+[duplicate submissions](#i-m-receiving-duplicate-submissions) for the causes.
+
 ## I'm receiving duplicate submissions
+
+Duplicates come from one of two places, and they need different fixes. Check the
+submitted content first: a real visitor sending twice looks like a genuine
+enquiry, while a burst of many identical copies seconds apart is almost always a
+bot.
+
+### Duplicates from a real visitor
 
 Common causes:
 
+- The submit button was clicked multiple times before the request completed.
 - The visitor pressed the back button after submitting and resubmitted the form on refresh.
-- The submit button was clicked multiple times before the request completed. Disable the button while the request is in flight.
 - Browser autofill / form-restore replayed the submission after a page reload.
 
-If you submit via AJAX, disable the button until the request resolves and reset the form on success. For full-page submissions, redirect away from the form on success to avoid resubmission on refresh.
+Guard the submit button while the request is in flight. Reset it in a `finally`
+block so a failed request does not leave the form permanently disabled:
+
+```html
+<form id="form">
+  <input type="email" name="email" required />
+  <button id="button" type="submit">Send</button>
+</form>
+
+<script>
+  const form = document.getElementById("form");
+  const button = document.getElementById("button");
+
+  form.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    if (button.disabled) return;
+    button.disabled = true;
+    try {
+      const response = await fetch("https://submit-form.com/your-form-id", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+        body: JSON.stringify(Object.fromEntries(new FormData(form))),
+      });
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      form.reset();
+    } catch (error) {
+      console.error(error);
+    } finally {
+      button.disabled = false;
+    }
+  });
+</script>
+```
+
+Most of the [framework examples](/examples/react) already wire this up through a
+`submitting` flag. For full-page submissions without AJAX, redirect away from the
+form on success so a refresh cannot resubmit it.
+
+### Duplicates from a bot
+
+A bot posts straight to your form endpoint and never loads your page, so
+disabling the button, resetting the form, and redirecting on success have no
+effect on it. Those guards only stop a real visitor submitting twice.
+
+Enable [spam protection](/setup/spam-protection) instead. Every accepted copy
+spends one submission from your workspace, so bot bursts eat into your allowance
+as well as your inbox, and submissions rejected as spam do not count against
+your total. See [limits and plans](/troubleshooting/limits-and-plans).


### PR DESCRIPTION
Prompted by a support ticket: a customer reported "the same notification 7 times". It was 7 byte-identical submissions 224ms apart from an SEO bot, one notification each, working as designed. The troubleshooting page had a duplicate submissions section, but everything in it addressed a problem she did not have.

## What was wrong

The section listed only visitor-created causes (back button, double click, autofill replay) and every remedy was client side. A bot posts straight to the form endpoint and never loads the page, so disabling the submit button, resetting the form and redirecting on success have no effect on it. A burst of identical copies seconds apart is the shape support sees most often, and readers were being pointed at fixes that cannot reach it.

## Changes

- Split the section by origin, since the two causes share no remedy, and lead with how to tell them apart from the submitted content.
- Added a vanilla JS guard for the visitor case, for people not on a framework. The button is released in a `finally` block so a failed request cannot leave the form permanently disabled. The framework examples already do this via a `submitting` flag, so they are linked rather than duplicated.
- Said plainly in the bot half that client side guards do not apply, and pointed at spam protection.
- Added a heading for "I'm receiving the same notification several times". Formspark sends one notification per accepted submission, so repeated emails mean repeated submissions. People search the notification wording and previously landed on nothing.
- Noted that accepted duplicates spend submissions while spam rejections do not, which is the argument for enabling protection.

## Verification

- `npx prettier --check` passes.
- `npm run build` succeeds.
- All four headings generate anchors; the in-page link to `#i-m-receiving-duplicate-submissions` resolves.
- Outbound links checked against the build output: `/setup/spam-protection`, `/examples/react`, `/troubleshooting/limits-and-plans` all exist.
