### PR TITLE
Document account settings, deletion included

### DIFF
--- a/docs/.vitepress/sidebar.js
+++ b/docs/.vitepress/sidebar.js
@@ -54,6 +54,10 @@ export const sidebar = [
         text: "Exporting submissions",
         link: "/dashboard/exporting-submissions",
       },
+      {
+        text: "Account settings",
+        link: "/dashboard/account-settings",
+      },
     ],
   },
   {

--- a/docs/dashboard/account-settings.md
+++ b/docs/dashboard/account-settings.md
@@ -1,0 +1,91 @@
+---
+title: Account settings
+lang: en-US
+---
+
+# Account settings
+
+Settings that belong to you rather than to one of your workspaces. Open them
+from the avatar menu in the dashboard, or go straight to
+[your settings](https://dashboard.formspark.io/account/api-tokens).
+
+Workspace settings, including billing, team members and deleting a single
+workspace, live with the workspace instead.
+
+## API tokens
+
+Tokens let scripts and tools use Formspark on your behalf. A token belongs to
+you and reaches every workspace you are a member of, limited to the scopes you
+give it. The API itself is available on paid workspaces.
+
+A token is shown once, when you create it. If you lose it, revoke it and create
+another. Revoking takes effect immediately.
+
+See [API tokens](/api/api-tokens) for the scopes, expiry and usage.
+
+## Deleting your account
+
+Go to **Settings → Delete account**. You will be shown exactly what is about to
+be removed and asked to type your email address to confirm.
+
+Deletion cannot be undone. Nothing is archived and nothing can be restored
+afterwards, so export anything you want to keep first. See
+[exporting submissions](/dashboard/exporting-submissions).
+
+### What is removed
+
+- Every workspace you are the only member of, along with its forms,
+  submissions, notification settings and integrations.
+- Your membership of workspaces shared with other people. Those workspaces
+  themselves are left alone, together with everything in them.
+- Your API tokens. Anything still using one stops working immediately.
+- Your email address, on every form that notifies it.
+
+### What is kept
+
+Your sign-in is kept, so you can come back later with the same address rather
+than registering again. You will arrive with no workspaces.
+
+The free submissions included with your original signup are not granted a
+second time. Any workspace you create after deleting starts empty, and you can
+add submissions to it with a bundle. See
+[limits and plans](/troubleshooting/limits-and-plans).
+
+Records we are required to retain for accounting, such as payment records for
+bundles you have bought, are held by our payment provider and are unaffected.
+
+### Your address is removed from other people's forms too
+
+Deleting your account takes your address off every form that sends
+notifications to it, not only the forms in your own workspaces. That includes
+forms belonging to people you have never shared a workspace with, if someone
+added you as a recipient.
+
+Aliases of the same mailbox go with it. Deleting an account on
+`you@gmail.com` also clears `you+forms@gmail.com` and `y.o.u@gmail.com`,
+because they all deliver to you.
+
+If you were the only recipient on someone else's form, that form will no longer
+notify anyone until its owner adds a new recipient. Tell them before you delete
+if that matters.
+
+### If you are the only administrator of a shared workspace
+
+Deletion is refused while you are the only administrator of a workspace that
+other people are members of. Removing you would leave that workspace with
+nobody able to manage it.
+
+The dashboard lists the workspaces holding you up. For each one, either:
+
+- Promote another member to administrator, then delete your account. The
+  workspace and its data stay with them. See
+  [inviting team members](/dashboard/inviting-team-members).
+- Or remove the other members, which turns it into a workspace you are alone
+  in, and it will then be deleted along with everything in it.
+
+### Purchased submissions are not refunded
+
+If a workspace being deleted still holds submissions from a bundle, those are
+lost with it. Bundles belong to a workspace rather than to you, so if you want
+to preserve one, hand that workspace to another administrator instead of
+deleting it.

--- a/docs/troubleshooting/common-issues.md
+++ b/docs/troubleshooting/common-issues.md
@@ -24,6 +24,21 @@ lang: en-US
 
 Ensure that you are signed in with the correct email address.
 
+## I want to delete my account
+
+You can do this yourself, under
+[Settings → Delete account](https://dashboard.formspark.io/account/delete).
+
+It removes the workspaces you are the only member of, along with their forms
+and submissions, and takes your address off every form that notifies it. Your
+sign-in is kept so you can come back later, and it cannot be undone. See
+[account settings](/dashboard/account-settings#deleting-your-account) for what
+is removed, what is kept, and what to do if you are the only administrator of a
+shared workspace.
+
+To delete a single workspace rather than your whole account, open that
+workspace's settings instead.
+
 ## My workspace suddenly seems to be out of submissions
 
 Ensure that you are connected to the right workspace: [View My Workspaces](https://dashboard.formspark.io/workspaces).


### PR DESCRIPTION
Account deletion is a recurring support question with nothing to point people at, and the dashboard is about to grow a Delete account button that needs somewhere to link. Pairs with the monorepo change that adds the feature.

## Changes

- New **Account settings** page under Dashboard, mirroring the settings that belong to a person rather than a workspace. It carries two anchors, `#api-tokens` and `#deleting-your-account`, because both are linked to directly (the dashboard deep-links the second one).
- The API tokens section describes the tab and defers to `/api/api-tokens` for scopes, expiry and usage, rather than restating them somewhere that can drift.
- The deletion section spells out what is removed and what is kept. The sign-in survives, so the free allowance is not granted a second time and a new workspace starts empty.
- Documents two consequences users would otherwise hit blind: the address is cleared from every form that notified it including forms owned by other people (which can leave those forms with no recipient), and aliases of the same mailbox go with it.
- Covers the block that applies while someone is the only administrator of a shared workspace, and that purchased bundles are not refunded.
- Adds an "I want to delete my account" entry to common issues, and distinguishes deleting an account from deleting a single workspace.

## Ordering

This should land before the monorepo change. `AccountDeleteScreen.tsx` links to `account-settings.html#deleting-your-account`; if the dashboard ships first that link 404s until this deploys.

## Verification

- `npx prettier --check` passes.
- `npm run build` succeeds.
- Both anchors present in the built HTML (`id="api-tokens"`, `id="deleting-your-account"`).
- Outbound links checked against the build output: `/api/api-tokens`, `/dashboard/exporting-submissions`, `/dashboard/inviting-team-members`, `/troubleshooting/limits-and-plans`.
